### PR TITLE
Implement MsgMultiSend visualization

### DIFF
--- a/src/components/tx/MessageMultiSend.tsx
+++ b/src/components/tx/MessageMultiSend.tsx
@@ -1,0 +1,65 @@
+import React, {useMemo} from "react";
+import {useTranslation} from "react-i18next";
+import {useCurrentChainInfo} from "@desmoslabs/sdk-react";
+import {convertCoin} from "@desmoslabs/sdk-core";
+import {MsgMultiSend} from "cosmjs-types/cosmos/bank/v1beta1/tx";
+import {SimpleMessageComponent} from "./SimpleMessageComponent";
+import {MsgMultiSendEncodeObject} from "../../types/encodeobject";
+
+
+export type Props = {
+    protobufMessage?: MsgMultiSend
+    encodeObject?: MsgMultiSendEncodeObject["value"],
+}
+
+export const MessageMultiSend: React.FC<Props> = ({protobufMessage, encodeObject}) => {
+    const {t} = useTranslation();
+    const chainInfo = useCurrentChainInfo();
+
+
+    const amounts = useMemo(() => {
+        const inputs = protobufMessage?.inputs ?? encodeObject?.inputs ?? [];
+
+        return inputs.map(input => {
+            const serializedCoins = input.coins.map(c => convertCoin(c, 6, chainInfo.denomUnits))
+                .filter(c => c !== null)
+                .map(c => `${c!.amount} ${c!.denom.toUpperCase()}`)
+                .join("\n");
+            return `${serializedCoins}`
+        }).join(", ");
+    }, [chainInfo.denomUnits, encodeObject?.inputs, protobufMessage?.inputs]);
+
+    const outputs = useMemo(() => {
+        const outputs = protobufMessage?.outputs ?? encodeObject?.outputs ?? [];
+
+        return outputs.map(output => {
+            const serializedCoins = output.coins.map(c => convertCoin(c, 6, chainInfo.denomUnits))
+                .filter(c => c !== null)
+                .map(c => `${c!.amount} ${c!.denom.toUpperCase()}`)
+                .join("\n");
+            return {
+                amount: serializedCoins,
+                to: output.address,
+            }
+        }).map(serializedOutput => {
+            return [
+                {
+                    label: t("to"),
+                    value: serializedOutput.to
+                },
+                {
+                    label: t("amount"),
+                    value: serializedOutput.amount
+                },
+            ]
+        }).reduce((oldValue, value) => [...oldValue, ...value], []);
+    }, [chainInfo.denomUnits, encodeObject?.outputs, protobufMessage?.outputs, t]);
+
+    return <SimpleMessageComponent
+        icon={require("../../assets/tx-icons/send.png")}
+        iconSubtitle={amounts}
+        fields={[
+            ...outputs
+        ]}
+    />
+}

--- a/src/components/tx/TxMessage.tsx
+++ b/src/components/tx/TxMessage.tsx
@@ -6,7 +6,7 @@ import {EncodeObject} from "@cosmjs/proto-signing";
 import {SaveProfileMessage} from "./SaveProfileMessage";
 import {UnknownTxMessage} from "./UnknownTxMessage";
 import {MessageSend} from "./MessageSend";
-import {MsgSend} from "cosmjs-types/cosmos/bank/v1beta1/tx";
+import {MsgMultiSend, MsgSend} from "cosmjs-types/cosmos/bank/v1beta1/tx";
 import {MsgTypes} from "../../types/msgtypes";
 import {MessageVote} from "./MessageVote";
 import {MsgVote} from "cosmjs-types/cosmos/gov/v1beta1/tx";
@@ -17,6 +17,7 @@ import {MsgWithdrawDelegatorReward} from "cosmjs-types/cosmos/distribution/v1bet
 import {MessageLinkChainAccount} from "./MessageLinkChainAccount";
 import {MsgLinkChainAccount, MsgUnlinkChainAccount} from "@desmoslabs/proto/desmos/profiles/v1beta1/msgs_chain_links";
 import {MessageUnlinkChainAccount} from "./MessageUnlinkChainAccount";
+import {MessageMultiSend} from "./MessageMultiSend";
 
 
 export type Props = {
@@ -44,6 +45,13 @@ export const TxMessage: React.FC<Props> = (props) => {
             return <MessageSend protobufMessage={decodedMessage}/>
         } else {
             return <MessageSend encodeObject={value}/>
+        }
+    } else if (typeUrl === MsgTypes.MsgMultiSend) {
+        if (isProtobuf) {
+            const decodedMessage = MsgMultiSend.decode(value);
+            return <MessageMultiSend protobufMessage={decodedMessage}/>
+        } else {
+            return <MessageMultiSend encodeObject={value}/>
         }
     } else if (typeUrl === MsgTypes.MsgVote) {
         if (isProtobuf) {

--- a/src/components/tx/list/MessageMultiSendListItem.tsx
+++ b/src/components/tx/list/MessageMultiSendListItem.tsx
@@ -1,0 +1,48 @@
+import React, {useMemo} from "react";
+import {convertCoin} from "@desmoslabs/sdk-core";
+import {View} from "react-native";
+import {useCurrentChainInfo} from "@desmoslabs/sdk-react";
+import {BaseMessageListItem} from "./BaseMessageListItem";
+import {Typography} from "../../typography";
+import {useTranslation} from "react-i18next";
+import {MsgMultiSendEncodeObject} from "../../../types/encodeobject";
+
+export type Props = {
+    encodeObject: MsgMultiSendEncodeObject,
+    date: Date,
+}
+
+export const MessageMultiSendListItem: React.FC<Props> = (props) => {
+    const {encodeObject, date} = props;
+    const {t} = useTranslation();
+    const currentChainInfo = useCurrentChainInfo();
+
+    const tokenSent = useMemo(() => {
+        return encodeObject.value.inputs?.map(input => {
+            return input.coins.map(c => convertCoin(c, 6, currentChainInfo.denomUnits))
+                .filter(c => c !== null)
+                .map(c => `${c?.amount} ${c?.denom.toUpperCase()}`)
+                .join(", ");
+        }).join(", ");
+    }, [currentChainInfo.denomUnits, encodeObject.value.inputs]);
+
+    const outputAddresses = useMemo(() => {
+        return encodeObject.value.outputs.map(output => output.address);
+    }, [encodeObject.value.outputs])
+
+    return <BaseMessageListItem
+        icon={require("../../../assets/tx-icons/send.png")}
+        date={date}
+        renderContent={() => <View>
+            <Typography.Body1>{t("multi send")} {tokenSent}</Typography.Body1>
+            <Typography.Caption>{t("to")}</Typography.Caption>
+            {outputAddresses.map((address, index) => <Typography.Caption
+                key={index.toString()}
+                numberOfLines={1}
+                ellipsizeMode={"middle"}
+            >
+                {address}
+            </Typography.Caption>)}
+        </View>}
+    />
+}

--- a/src/components/tx/list/TransactionListMessageItem.tsx
+++ b/src/components/tx/list/TransactionListMessageItem.tsx
@@ -15,6 +15,8 @@ import {MessageDelegateListItem} from "./MessageDelegateListItem";
 import {MessageWithdrawDelegatorRewardListItem} from "./MessageWithdrawDelegatorRewardListItem";
 import {MessageLinkChainAccountListItem} from "./MessageLinkChainAccountListItem";
 import {MessageUnlinkChainAccountListItem} from "./MessageUnlinkChainAccountListItem";
+import {MessageMultiSendListItem} from "./MessageMultiSendListItem";
+import {MsgMultiSendEncodeObject} from "../../../types/encodeobject";
 
 export type Props = {
     encodeObject: EncodeObject,
@@ -29,6 +31,12 @@ export const TransactionListMessageItem: React.FC<Props> = (props) => {
             return <MessageSendListItem
                 encodeObject={encodeObject as MsgSendEncodeObject}
                 date={date} />
+
+        case MsgTypes.MsgMultiSend:
+            return <MessageMultiSendListItem
+                encodeObject={encodeObject as MsgMultiSendEncodeObject}
+                date={date}
+            />
 
         case MsgTypes.MsgSaveProfile:
             return <MessageSaveProfileListItem

--- a/src/graphql/hooks/useFetchTxsGrouppedByDate.ts
+++ b/src/graphql/hooks/useFetchTxsGrouppedByDate.ts
@@ -17,6 +17,7 @@ import Long from "long";
 import {Bech32Address} from "@desmoslabs/proto/desmos/profiles/v1beta1/models_chain_links";
 import {Any} from "cosmjs-types/google/protobuf/any";
 import {PubKey} from "cosmjs-types/cosmos/crypto/secp256k1/keys";
+import {MsgMultiSendEncodeObject} from "../../types/encodeobject";
 
 const LIMIT = 20;
 
@@ -55,6 +56,15 @@ function gqlMessageToEncodeObject(msg: any): EncodeObject {
                     fromAddress: msg["from_address"],
                 }
             } as MsgSendEncodeObject
+
+        case MsgTypes.MsgMultiSend:
+            return {
+                typeUrl: type,
+                value: {
+                    inputs: msg["inputs"],
+                    outputs: msg["outputs"],
+                }
+            } as MsgMultiSendEncodeObject
 
         case MsgTypes.MsgWithdrawDelegatorReward:
             return {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -97,6 +97,7 @@
   "Message Value": "Message value",
   "available": "Available",
   "send": "Send",
+  "multi send": "Multi send",
   "recipient address": "Recipient address",
   "insert address": "Insert address",
   "insert amount": "Insert amount",

--- a/src/types/encodeobject.ts
+++ b/src/types/encodeobject.ts
@@ -1,0 +1,7 @@
+import {EncodeObject} from "@cosmjs/proto-signing";
+import {MsgMultiSend} from "cosmjs-types/cosmos/bank/v1beta1/tx";
+
+export interface MsgMultiSendEncodeObject extends EncodeObject {
+    readonly typeUrl: "/cosmos.bank.v1beta1.MsgMultiSend",
+    readonly value: MsgMultiSend,
+}

--- a/src/types/msgtypes.ts
+++ b/src/types/msgtypes.ts
@@ -1,5 +1,6 @@
 export enum MsgTypes {
     MsgSend = "/cosmos.bank.v1beta1.MsgSend",
+    MsgMultiSend = "/cosmos.bank.v1beta1.MsgMultiSend",
     MsgWithdrawDelegatorReward = "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
     MsgVote = "/cosmos.gov.v1beta1.MsgVote",
     MsgDelegate = "/cosmos.staking.v1beta1.MsgDelegate",


### PR DESCRIPTION
## Description
This PR implements the visualization of the MsgMultiSend in the list of transactions and when visualizing the details of a transaction.

Closes: #28 

---

Transaction list:
![tx-list](https://user-images.githubusercontent.com/6245917/144212443-a64b82cc-13d0-41d2-b162-dffc1aa9b4db.png)

Transaction details:
![tx-details](https://user-images.githubusercontent.com/6245917/144212466-c43c5162-7858-4be8-a249-45ad3d36c11b.png)


