### PR TITLE
feat: use the first install time as salt and bump pbkdf2 to 100,100

### DIFF
--- a/src/lib/EncryptionUtils/index.ts
+++ b/src/lib/EncryptionUtils/index.ts
@@ -1,4 +1,5 @@
 import { NativeModules } from 'react-native';
+import * as DeviceInfo from 'react-native-device-info';
 
 const { Aes } = NativeModules;
 
@@ -11,8 +12,10 @@ export interface EncryptedData {
  * Derive a safe password using the pbkdf2 algorithm.
  * @param password The password from which will be derived the safer password.
  */
-export const deriveSecurePassword = async (password: string): Promise<string> =>
-  Aes.pbkdf2(password, password.normalize('NFKC'), 100000, 256);
+export const deriveSecurePassword = async (password: string): Promise<string> => {
+  const firstInstallTime = await DeviceInfo.getFirstInstallTime();
+  return Aes.pbkdf2(password, firstInstallTime.toString(), 100_100, 256);
+};
 
 /**
  * Encrypts the provided text using the AES algorithm.


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR bumps the pbkdf2 iterations to 100,100 and use the first instal time in ms as salt to prevent a rainbow table attack.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
