### PR TITLE
feat: add useHasAccount hook

### DIFF
--- a/src/hooks/useLockApplicationOnBlur.ts
+++ b/src/hooks/useLockApplicationOnBlur.ts
@@ -5,13 +5,13 @@ import { AppState, NativeEventSubscription, Platform } from 'react-native';
 import ROUTES from 'navigation/routes';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack/lib/typescript/src/types';
-import { useGetAccounts } from '@recoil/accounts';
+import { useHasAccount } from '@recoil/accounts';
 
 const useLockApplicationOnBlur = () => {
   const navigation = useNavigation<StackNavigationProp<RootNavigatorParamList>>();
   const appState = useAppState();
   const setAppState = useSetAppState();
-  const accounts = useGetAccounts();
+  const hasAccount = useHasAccount();
 
   const showSplashScreen = useCallback(() => {
     setAppState((currentState) => {
@@ -53,7 +53,7 @@ const useLockApplicationOnBlur = () => {
     }
 
     const onChangeSubscription = AppState.addEventListener('change', (state) => {
-      if (Object.keys(accounts).length === 0) {
+      if (!hasAccount) {
         return;
       }
 
@@ -87,7 +87,7 @@ const useLockApplicationOnBlur = () => {
       blurSubscription?.remove();
       focusSubscription?.remove();
     };
-  }, [accounts, navigation, setAppState, appState, showSplashScreen, removeSplashScreen]);
+  }, [hasAccount, navigation, setAppState, appState, showSplashScreen, removeSplashScreen]);
 
   useEffect(() => {
     if (appState.locked) {

--- a/src/hooks/useSaveAccount.ts
+++ b/src/hooks/useSaveAccount.ts
@@ -2,14 +2,14 @@ import { useCallback, useMemo } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack/lib/typescript/src/types';
 import { RootNavigatorParamList } from 'navigation/RootNavigator';
-import { useGetAccounts } from '@recoil/accounts';
+import { useHasAccount } from '@recoil/accounts';
 import { AccountWithWallet } from 'types/account';
 import ROUTES from 'navigation/routes';
 
 const useSaveAccount = () => {
   const navigator = useNavigation<StackNavigationProp<RootNavigatorParamList>>();
-  const accounts = useGetAccounts();
-  const createWalletPassword = useMemo(() => Object.keys(accounts).length === 0, [accounts]);
+  const hasAccount = useHasAccount();
+  const createWalletPassword = useMemo(() => hasAccount, [hasAccount]);
 
   return useCallback(
     (account: AccountWithWallet) => {

--- a/src/recoil/accounts.ts
+++ b/src/recoil/accounts.ts
@@ -56,6 +56,22 @@ export const useStoreAccount = () => {
 };
 
 /**
+ * Recoil select that allows to easily know if there is at least one account stored in the device or not.
+ */
+const hasAccountAppState = selector({
+  key: 'hasAccount',
+  get: ({ get }) => {
+    const accounts = get(accountsAppState);
+    return Object.keys(accounts).length > 0;
+  },
+});
+
+/**
+ * Hook that allows to easily know if there is at least one account stored inside the device or not.
+ */
+export const useHasAccount = () => useRecoilValue(hasAccountAppState);
+
+/**
  * Hook that allows to get the accounts stored on the device.
  */
 export const useGetAccounts = () => useRecoilValue(accountsAppState);

--- a/src/screens/SaveGeneratedAccount/useHooks.ts
+++ b/src/screens/SaveGeneratedAccount/useHooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { AccountWithWallet } from 'types/account';
 import {
   deleteItem,
@@ -7,17 +7,18 @@ import {
   SecureStorageKeys,
   setUserPassword,
 } from 'lib/SecureStorage';
-import { useGetAccounts, useStoreAccount } from '@recoil/accounts';
+import { useHasAccount, useStoreAccount } from '@recoil/accounts';
 
 export const useSaveAccount = () => {
-  const accounts = useGetAccounts();
+  const hasAccount = useHasAccount();
+  const savingFirstAccount = useMemo(() => !hasAccount, [hasAccount]);
+
   const storeAccount = useStoreAccount();
   const [savingAccount, setSavingAccount] = useState(false);
   const [saveAccountError, setError] = useState<string>();
 
   const saveAccount = useCallback(
     async ({ account, wallet }: AccountWithWallet, password: string) => {
-      const savingFirstAccount = Object.keys(accounts).length === 0;
       try {
         setSavingAccount(true);
         setError(undefined);
@@ -33,14 +34,13 @@ export const useSaveAccount = () => {
           deleteItem(SecureStorageKeys.PASSWORD_CHALLENGE);
         }
         deleteWallet(wallet.address);
-
         setError(e.toString());
         throw e;
       } finally {
         setSavingAccount(false);
       }
     },
-    [accounts, storeAccount],
+    [savingFirstAccount, storeAccount],
   );
 
   return {


### PR DESCRIPTION
## Description

This PR introduces the new `useHasAccount` hook to know whether ot not the user has one account stored inside the device. By doing this we should limit the re-creation of hooks that previously relied on the entire accounts list. Instead of being re-created each time an account is added or removed, this hook is triggered only when the accounts list has its first item added or its last item removed.  

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
