### PR TITLE
fix: balance not visible for accounts that don't have coins

### DIFF
--- a/src/hooks/useActiveAccountBalance.ts
+++ b/src/hooks/useActiveAccountBalance.ts
@@ -1,20 +1,29 @@
 import { useQuery } from '@apollo/client';
 import GetAccountBalance from 'services/graphql/queries/GetAccountBalance';
 import { useMemo } from 'react';
-import { Coin } from '@cosmjs/amino';
+import { coin, Coin } from '@cosmjs/amino';
 import { useActiveAccountAddress } from '@recoil/activeAccount';
+import { useCurrentChainInfo } from '@recoil/settings';
 
 /**
  * Hook that allows to get the account balance for the currently active account.
  */
 const useActiveAccountBalance = () => {
   const address = useActiveAccountAddress();
+  const currentChainInfo = useCurrentChainInfo();
+
   const { data, loading, refetch } = useQuery(GetAccountBalance, {
     variables: { address: address || 'undefined' },
     fetchPolicy: 'cache-and-network',
   });
 
-  const balance = useMemo((): Coin[] => data?.accountBalance?.coins || [], [data]);
+  const balance = useMemo((): Coin[] => {
+    const coins = data?.accountBalance?.coins ?? [];
+    if (coins.length === 0) {
+      return [coin('0', currentChainInfo.stakeCurrency.coinMinimalDenom)];
+    }
+    return coins;
+  }, [currentChainInfo.stakeCurrency.coinMinimalDenom, data]);
   return {
     balance,
     loading,


### PR DESCRIPTION
## Description

This PR fixes the account balance component by displaying a 0 balance instead of nothing when the account does not have any coins.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
