### PR TITLE
fix: fix splash screen not been visualized on Android after unlocking the device

### DIFF
--- a/src/hooks/useGetPasswordFromBiometrics.ts
+++ b/src/hooks/useGetPasswordFromBiometrics.ts
@@ -2,12 +2,29 @@ import { useCallback } from 'react';
 import { getBiometricPassword } from 'lib/SecureStorage';
 import { BiometricAuthorizations } from 'types/settings';
 import { useSetAppState } from '@recoil/appState';
+import { Platform } from 'react-native';
+import { appStateOnce } from 'lib/AppStateUtils';
 
 const useGetPasswordFromBiometrics = (biometricAuthorization: BiometricAuthorizations) => {
   const setAppState = useSetAppState();
 
   return useCallback(() => {
     setAppState((currentState) => ({ ...currentState, noSplashScreen: true }));
+    if (Platform.OS === 'android') {
+      // In android if we are requesting the biometrics shortly after the user have
+      // unlocked is phone the application don't show the biometrics popup in this case
+      // we don't need to prevent the visualization of the splash screen on the next
+      // blur event.
+      const cancelSplashIgnore = setTimeout(() => {
+        setAppState((currentState) => ({ ...currentState, noSplashScreen: false }));
+      }, 500);
+
+      appStateOnce('blur', () => {
+        // Application went on blur as expected, cancel the timeout that will
+        // force the visualization of the splash screen.
+        clearTimeout(cancelSplashIgnore);
+      });
+    }
     return getBiometricPassword(biometricAuthorization);
   }, [biometricAuthorization, setAppState]);
 };

--- a/src/hooks/useGetPasswordFromBiometrics.ts
+++ b/src/hooks/useGetPasswordFromBiometrics.ts
@@ -11,8 +11,8 @@ const useGetPasswordFromBiometrics = (biometricAuthorization: BiometricAuthoriza
   return useCallback(() => {
     setAppState((currentState) => ({ ...currentState, noSplashScreen: true }));
     if (Platform.OS === 'android') {
-      // In android if we are requesting the biometrics shortly after the user have
-      // unlocked is phone the application don't show the biometrics popup in this case
+      // On Android if we are requesting the biometrics shortly after the user has
+      // unlocked is phone the application won't show the biometrics popup. In this case
       // we don't need to prevent the visualization of the splash screen on the next
       // blur event.
       const cancelSplashIgnore = setTimeout(() => {

--- a/src/lib/AppStateUtils/index.ts
+++ b/src/lib/AppStateUtils/index.ts
@@ -1,0 +1,13 @@
+import { AppState, AppStateEvent, AppStateStatus } from 'react-native';
+
+/**
+ * Function to subscribe to an AppState event just for one event change.
+ * @param type - App state event.
+ * @param listener - Callback called on when the event is fired.
+ */
+export const appStateOnce = (type: AppStateEvent, listener: (state: AppStateStatus) => void) => {
+  const subscription = AppState.addEventListener(type, (state: AppStateStatus) => {
+    listener(state);
+    subscription.remove();
+  });
+};


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR fixes a bug that cause the missing visualization of the splash screen on Android when the application goes on `blur`. This is caused from the fact that if the application requires the biometrics authentication shortly after the user have unlocked the device the biometrics popup is not showed to the user and so the application don't goes on `blur` state and the `noSplashScreen` flag is not cleared causing the application to not show the splash screen if the user opens another application.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
