### PR TITLE
feat: allow to customize import account screen title and description

### DIFF
--- a/src/hooks/useImportAccount.ts
+++ b/src/hooks/useImportAccount.ts
@@ -10,6 +10,11 @@ import importAccountAppState from '@recoil/importAccountState';
 import { getChainSupportedWalletTypes } from 'lib/ChainsUtils';
 import useReturnToCurrentScreen from 'hooks/useReturnToCurrentScreen';
 
+type ImportAccountOptions = {
+  title: string;
+  description: string;
+};
+
 type AccountWithWalletAndChain = {
   account: AccountWithWallet;
   chain: SupportedChain;
@@ -19,11 +24,16 @@ type AccountWithWalletAndChain = {
  * Hook that starts a flow that allow the user to import an account from either one of the supported chains.
  * @param chains - List of supported chains to be showed during the import flow.
  * @param ignoreAddresses - List of addresses that will be ignored during the account generation.
+ * @param options - Details to be used on the next screen.
  *
  * <b>Note</b>: If the {@param chains} list only contains one item, the screen allowing to select the chain
  * to be imported will be skipped.
  */
-const useImportAccount = (chains: SupportedChain[], ignoreAddresses?: string[]) => {
+const useImportAccount = (
+  chains: SupportedChain[],
+  ignoreAddresses?: string[],
+  options?: ImportAccountOptions,
+) => {
   const navigation = useNavigation<StackNavigationProp<RootNavigatorParamList>>();
   const [, setImportAccountState] = useRecoilState(importAccountAppState);
   const returnToCurrentScreen = useReturnToCurrentScreen();
@@ -46,19 +56,23 @@ const useImportAccount = (chains: SupportedChain[], ignoreAddresses?: string[]) 
         },
       });
 
-      navigation.navigate({
-        name:
-          selectedChain === undefined
-            ? ROUTES.IMPORT_ACCOUNT_SELECT_CHAIN
-            : ROUTES.IMPORT_ACCOUNT_SELECT_TYPE,
-        params: undefined,
-      });
+      switch (selectedChain) {
+        case undefined:
+          navigation.navigate(ROUTES.IMPORT_ACCOUNT_SELECT_CHAIN);
+          break;
+        default:
+          navigation.navigate(ROUTES.IMPORT_ACCOUNT_SELECT_TYPE, {
+            title: options?.title,
+            description: options?.description,
+          });
+          break;
+      }
     });
 
     await returnToCurrentScreen();
     // setImportAccountState(undefined);
     return data;
-  }, [chains, ignoreAddresses, navigation, returnToCurrentScreen, setImportAccountState]);
+  }, [chains, ignoreAddresses, navigation, options, returnToCurrentScreen, setImportAccountState]);
 };
 
 export default useImportAccount;

--- a/src/navigation/RootNavigator/index.tsx
+++ b/src/navigation/RootNavigator/index.tsx
@@ -16,7 +16,9 @@ import ConnectToLedgerStack, {
 import Profile, { ProfileParams } from 'screens/Profile';
 import ChainLinkDetails, { ChainLinkDetailsParams } from 'screens/ChainLinkDetails';
 import ImportAccountSelectChain from 'screens/ImportAccountSelectChain';
-import ImportAccountSelectType from 'screens/ImportAccountSelectType';
+import ImportAccountSelectType, {
+  ImportAccountSelectTypeParams,
+} from 'screens/ImportAccountSelectType';
 import ImportAccountSelectLedgerApp from 'screens/ImportAccountSelectLedgerApp';
 import UnlockWallet, { UnlockWalletParams } from 'screens/UnlockWallet';
 import SendTokens from 'screens/SendTokens';
@@ -52,7 +54,7 @@ export type RootNavigatorParamList = {
   [ROUTES.LEGAL]: LegalParams;
   [ROUTES.CREATE_NEW_MNEMONIC]: undefined;
   [ROUTES.IMPORT_ACCOUNT_SELECT_CHAIN]: undefined;
-  [ROUTES.IMPORT_ACCOUNT_SELECT_TYPE]: undefined;
+  [ROUTES.IMPORT_ACCOUNT_SELECT_TYPE]: ImportAccountSelectTypeParams | undefined;
   [ROUTES.IMPORT_ACCOUNT_FROM_MNEMONIC]: undefined;
   [ROUTES.IMPORT_ACCOUNT_SELECT_LEDGER_APP]: undefined;
   [ROUTES.CHECK_MNEMONIC]: CheckMnemonicParams;

--- a/src/screens/CheckWalletPassword/index.tsx
+++ b/src/screens/CheckWalletPassword/index.tsx
@@ -92,8 +92,10 @@ const CheckWalletPassword = (props: NavProps) => {
   );
 
   return (
-    <StyledSafeAreaView style={styles.root} topBar={<TopBar stackProps={props} />}>
-      <Typography.Title>{t('confirm password')}</Typography.Title>
+    <StyledSafeAreaView
+      style={styles.root}
+      topBar={<TopBar stackProps={props} title={t('confirm password')} />}
+    >
       <View style={styles.passwordLabel}>
         <Typography.Body>{t('enter security password')}</Typography.Body>
       </View>

--- a/src/screens/ImportAccountSelectType/index.tsx
+++ b/src/screens/ImportAccountSelectType/index.tsx
@@ -1,5 +1,5 @@
 import { StackScreenProps } from '@react-navigation/stack';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import Typography from 'components/Typography';
 import StyledSafeAreaView from 'components/StyledSafeAreaView';
@@ -17,9 +17,16 @@ import ImageButton from './components/ImageButton';
 
 type NavProps = StackScreenProps<RootNavigatorParamList, ROUTES.IMPORT_ACCOUNT_SELECT_TYPE>;
 
-const ImportAccountSelectType: React.FC<NavProps> = ({ navigation }) => {
+export interface ImportAccountSelectTypeParams {
+  readonly title?: string;
+  readonly description?: string;
+}
+
+const ImportAccountSelectType = (props: NavProps) => {
   const { t } = useTranslation('account');
   const styles = useStyles();
+  const { navigation } = props;
+  const { params } = props.route;
 
   const [importAccountState, setImportAccountState] = useRecoilState(importAccountAppState);
   const { onCancel, chains, supportedImportMode } = importAccountState!;
@@ -80,14 +87,18 @@ const ImportAccountSelectType: React.FC<NavProps> = ({ navigation }) => {
     [styles, t, onImportModeSelected],
   );
 
+  const title = useMemo(() => (params?.title ? params.title : t('connect chain')), [params, t]);
+  const description = useMemo(
+    () => (params?.description ? params.description : t('select connection method')),
+    [params, t],
+  );
+
   return (
-    <StyledSafeAreaView
-      style={styles.background}
-      topBar={
-        <TopBar style={styles.background} stackProps={{ navigation }} title={t('connect chain')} />
-      }
-    >
-      <Typography.Body>{t('select connection method')}</Typography.Body>
+    <StyledSafeAreaView topBar={<TopBar stackProps={{ navigation }} title={title} />}>
+      {/* Description */}
+      <Typography.Body>{description}</Typography.Body>
+
+      {/* Import type list */}
       <FlatList data={supportedImportMode!} renderItem={renderWalletTypeItem} />
     </StyledSafeAreaView>
   );

--- a/src/screens/Landing/index.tsx
+++ b/src/screens/Landing/index.tsx
@@ -22,7 +22,10 @@ const Landing = ({ navigation }: NavProps) => {
   const styles = useStyles();
 
   const accountsAddresses = useStoredAccountsAddresses();
-  const importAccount = useImportAccount([DesmosChain], accountsAddresses);
+  const importAccount = useImportAccount([DesmosChain], accountsAddresses, {
+    title: t('account:import account'),
+    description: t('account:select import method'),
+  });
   const saveAccount = useSaveAccount();
 
   const animate = !navigation.canGoBack();


### PR DESCRIPTION
## Description

This PR adds the ability to customize the title and description of the screen allowing to import an account, to distinguish between when an account is imported inside the app and when a chain is being linked. 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
