### PR TITLE
feat: improve profile loading

### DIFF
--- a/src/assets/locales/en/profile.json
+++ b/src/assets/locales/en/profile.json
@@ -1,4 +1,5 @@
 {
+  "loading profile": "Loading profile",
   "edit profile": "Edit profile",
   "create profile": "Create profile",
   "cover picture": "Cover picture",

--- a/src/screens/Profile/components/ApplicationLinks/index.tsx
+++ b/src/screens/Profile/components/ApplicationLinks/index.tsx
@@ -7,7 +7,6 @@ import Spacer from 'components/Spacer';
 import useStyles from './useStyles';
 
 export interface ApplicationLinksProps {
-  readonly loading: boolean;
   readonly applicationLinks: ApplicationLink[];
   readonly canEdit: boolean;
 }

--- a/src/screens/Profile/components/ChainLinksList/index.tsx
+++ b/src/screens/Profile/components/ChainLinksList/index.tsx
@@ -9,7 +9,6 @@ import { DPMImages } from 'types/images';
 import useShowModal from 'hooks/useShowModal';
 import SingleButtonModal from 'modals/SingleButtonModal';
 import { ChainLink } from 'types/desmos';
-import StyledActivityIndicator from 'components/StyledActivityIndicator';
 import ChainLinkItem from '../ChainLinkItem';
 import useStyles from './useStyles';
 import useConnectChain from './useHooks';
@@ -17,12 +16,11 @@ import useConnectChain from './useHooks';
 export interface ChainConnectionsProps {
   canEdit: boolean;
   chainLinks: ChainLink[];
-  loading: boolean;
 }
 
 const ChainLinksList = (props: ChainConnectionsProps) => {
   const { t } = useTranslation('chainLinks');
-  const { canEdit, chainLinks, loading } = props;
+  const { canEdit, chainLinks } = props;
   const hasConnections = chainLinks.length !== 0;
   const styles = useStyles();
 
@@ -69,30 +67,26 @@ const ChainLinksList = (props: ChainConnectionsProps) => {
 
   return (
     <View style={styles.root}>
-      {/* Loading indicator */}
-      {loading && <StyledActivityIndicator />}
-
       {/* Chain links list */}
-      {!loading && (
-        <View style={styles.connectionsContainer}>
-          {hasConnections && (
-            <Typography.Body1 style={styles.connectionsListTitle}>
-              {t('connected chains')}
-            </Typography.Body1>
-          )}
-          <FlatList
-            style={styles.connectionsList}
-            data={chainLinks}
-            renderItem={renderItem}
-            keyExtractor={(item) => item.chainName + item.externalAddress}
-            ItemSeparatorComponent={ListItemSeparator}
-            ListEmptyComponent={ListEmptyComponent}
-          />
-        </View>
-      )}
+
+      <View style={styles.connectionsContainer}>
+        {hasConnections && (
+          <Typography.Body1 style={styles.connectionsListTitle}>
+            {t('connected chains')}
+          </Typography.Body1>
+        )}
+        <FlatList
+          style={styles.connectionsList}
+          data={chainLinks}
+          renderItem={renderItem}
+          keyExtractor={(item) => item.chainName + item.externalAddress}
+          ItemSeparatorComponent={ListItemSeparator}
+          ListEmptyComponent={ListEmptyComponent}
+        />
+      </View>
 
       {/* Connect button */}
-      {canEdit && !loading && hasConnections && (
+      {canEdit && hasConnections && (
         <Button style={styles.connectChainButton} onPress={connectChain} mode="outlined">
           {t('connect chain')}
         </Button>

--- a/src/screens/Profile/components/ProfileData/index.tsx
+++ b/src/screens/Profile/components/ProfileData/index.tsx
@@ -1,13 +1,10 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import ProfileHeader from 'components/ProfileHeader';
 import { View } from 'react-native';
 import Typography from 'components/Typography';
-import { DesmosProfile } from 'types/desmos';
+import { ApplicationLink, ChainLink, DesmosProfile } from 'types/desmos';
 import Spacer from 'components/Spacer';
-import useChainLinksGivenAddress from 'hooks/useChainLinksGivenAddress';
-import { useFocusEffect } from '@react-navigation/native';
 import ApplicationLinks from 'screens/Profile/components/ApplicationLinks';
-import useApplicationLinksGivenAddress from 'hooks/useApplicationLinksGivenAddress';
 import NonExistingProfile from '../NonExistingProfile';
 import ChainLinks from '../ChainLinksList';
 import useStyles from './useStyles';
@@ -19,34 +16,24 @@ export interface ProfileDataProps {
   profile: DesmosProfile | undefined;
 
   /**
+   * Chain links associated with the profile that should be displayed.
+   */
+  chainLinks: ChainLink[];
+
+  /**
+   * Application links associated with the profile that should be displayed.
+   */
+  applicationLinks: ApplicationLink[];
+
+  /**
    * Whether the profile data shown can be edited or not.
    */
   canEdit: boolean;
 }
 
 const ProfileData = (props: ProfileDataProps) => {
-  const { profile, canEdit } = props;
+  const { profile, canEdit, chainLinks, applicationLinks } = props;
   const styles = useStyles();
-
-  const {
-    chainLinks,
-    loading: areChainLinksLoading,
-    refetch: updateChainLinks,
-  } = useChainLinksGivenAddress(profile?.address);
-
-  const {
-    applicationLinks,
-    loading: areApplicationLinksLoading,
-    refetch: updateApplicationLinks,
-  } = useApplicationLinksGivenAddress(profile?.address);
-
-  useFocusEffect(
-    useCallback(() => {
-      // Refresh the data
-      updateChainLinks();
-      updateApplicationLinks();
-    }, [updateApplicationLinks, updateChainLinks]),
-  );
 
   return (
     <View style={styles.root}>
@@ -67,13 +54,9 @@ const ProfileData = (props: ProfileDataProps) => {
         {profile ? (
           <View style={styles.linksContainer}>
             {applicationLinks.length > 0 && <Spacer paddingVertical={4} />}
-            <ApplicationLinks
-              loading={areApplicationLinksLoading}
-              applicationLinks={applicationLinks}
-              canEdit={canEdit}
-            />
+            <ApplicationLinks applicationLinks={applicationLinks} canEdit={canEdit} />
             <Spacer paddingVertical={8} />
-            <ChainLinks loading={areChainLinksLoading} chainLinks={chainLinks} canEdit={canEdit} />
+            <ChainLinks chainLinks={chainLinks} canEdit={canEdit} />
           </View>
         ) : (
           <NonExistingProfile canCreate={canEdit} />


### PR DESCRIPTION
## Description

This PR improves the loading of the profile screen by using the `LoadingModal` instead of a `StyledActivityIndicator`. All data is now also loaded in the same place (right after opening the profile screen), instead of in two different places (`Profile` and `ProfileData`). This should provide a better UX by allowing the user to visualize the profile data only when all the data are properly loaded. 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
