### PR TITLE
fix: fix biometrics passwords not updated when changing application password

### DIFF
--- a/src/lib/SecureStorage/index.ts
+++ b/src/lib/SecureStorage/index.ts
@@ -234,6 +234,17 @@ export const changeWalletsPassword = async (oldPassword: string, newPassword: st
 
   // Update the global password challenge
   await setUserPassword(newPassword);
+
+  // Update the configured biometrics configurations with the new password.
+  const allKeys = await Keychain.getAllGenericPasswordServices();
+  const biometricsKeys = Object.values(BiometricAuthorizations).map(
+    (auth) => `${auth}${SecureStorageKeys.BIOMETRIC_AUTHORIZATION_SUFFIX}`,
+  );
+  const biometricsToUpdate = allKeys.filter((key) => biometricsKeys.indexOf(key) !== -1);
+  await Promise.all(
+    biometricsToUpdate.map((key) => setItem(key, newPassword, { biometrics: true })),
+  );
+
   return true;
 };
 


### PR DESCRIPTION
## Fix biometrics passwords not updated when changing application password

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR fixes a bug that prevent the authentication with biometrics if the user changes password after enabling the biometrics login or the sign transactions with biometrics.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
