### PR TITLE
fix: fixed first transactions section header not updating

### DIFF
--- a/src/screens/Home/components/TransactionsList/index.tsx
+++ b/src/screens/Home/components/TransactionsList/index.tsx
@@ -35,20 +35,22 @@ const TransactionsList = (props: TransactionsListProps) => {
     [styles.blankDivider],
   );
 
-  const stickyHeaderIndices = sections
-    .map((item, index) => {
-      if (typeof item === 'string') {
-        return index;
-      }
-      return null;
-    })
-    .filter((item) => item !== null) as number[];
+  // Disable the sticky header since there is a bug in FlashList that cause
+  // the first element to not update correctly when the date changes.
+  // See: https://github.com/Shopify/flash-list/issues/615
+  // const stickyHeaderIndices = sections
+  //   .map((item, index) => {
+  //     if (typeof item === 'string') {
+  //       return index;
+  //     }
+  //     return null;
+  //   })
+  //   .filter((item) => item !== null) as number[];
 
   return sections && !loading ? (
     <FlashList
       data={sections}
       renderItem={renderItem}
-      stickyHeaderIndices={stickyHeaderIndices}
       keyExtractor={(item, index) =>
         typeof item === 'string' ? `sectionHeader${index}` : `row${item.hash}`
       }

--- a/src/screens/Home/components/TransactionsList/index.tsx
+++ b/src/screens/Home/components/TransactionsList/index.tsx
@@ -35,7 +35,7 @@ const TransactionsList = (props: TransactionsListProps) => {
     [styles.blankDivider],
   );
 
-  // Disable the sticky header since there is a bug in FlashList that cause
+  // Disable the sticky header since there is a bug in FlashList that causes
   // the first element to not update correctly when the date changes.
   // See: https://github.com/Shopify/flash-list/issues/615
   // const stickyHeaderIndices = sections


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR fixes the transactions section header not updating correctly.  
Unfortunally the bug is casued from this issue (https://github.com/Shopify/flash-list/issues/615 ) of the `FlashList` library.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
