### PR TITLE
fix: fix return to current screen hook

### DIFF
--- a/src/hooks/useReturnToCurrentScreen.ts
+++ b/src/hooks/useReturnToCurrentScreen.ts
@@ -13,7 +13,12 @@ const useReturnToCurrentScreen = () => {
   }, [navigator]);
 
   return useCallback(() => {
-    navigator.navigate(startingScreenNavigateParams);
+    const canNavigate =
+      navigator.getState().routes.find((r) => r.key === startingScreenNavigateParams.key) !==
+      undefined;
+    if (canNavigate) {
+      navigator.navigate(startingScreenNavigateParams);
+    }
   }, [navigator, startingScreenNavigateParams]);
 };
 


### PR DESCRIPTION
## Description 

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR fixes the `useReturnToCurrentScreen` hook to execute the `navigate` action only if the screen where will should return exists in the navigator state.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
