### PR TITLE
fix: added a TouchableWithoutFeedback to close the keyboard on iOS + UI fixes

### DIFF
--- a/src/components/AvatarImage/useStyles.ts
+++ b/src/components/AvatarImage/useStyles.ts
@@ -11,12 +11,12 @@ const useStyles = makeStyleWithProps((props: AvatarImageProps, theme) => ({
     borderRadius: 100,
     height: props.size ?? 24,
     width: props.size ?? 24,
+    opacity: props.loading ? 0.5 : 1,
   },
   indicator: {
     position: 'absolute',
     width: '100%',
     height: '100%',
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
     borderRadius: 100,
   },
 }));

--- a/src/components/StyledSafeAreaView/index.tsx
+++ b/src/components/StyledSafeAreaView/index.tsx
@@ -1,5 +1,13 @@
 import React, { ReactElement } from 'react';
-import { ImageBackground, ScrollView, StatusBar, View, ViewProps } from 'react-native';
+import {
+  ImageBackground,
+  Keyboard,
+  ScrollView,
+  StatusBar,
+  TouchableWithoutFeedback,
+  View,
+  ViewProps,
+} from 'react-native';
 import { useTheme } from 'react-native-paper';
 import Divider from 'components/Divider';
 import useStyles from './useStyles';
@@ -31,10 +39,22 @@ export type StyledSafeAreaViewProps = ViewProps & {
    * If true removes the bottom padding on iOS bottom swipe area
    */
   noIosPadding?: boolean;
+  /**
+   * Enable touchable without feeback to close keyboard
+   */
+  touchableWithoutFeedbackDisabled?: boolean;
 };
 
 const StyledSafeAreaView: React.FC<StyledSafeAreaViewProps> = (props) => {
-  const { scrollable, topBar, divider, background, children, style } = props;
+  const {
+    scrollable,
+    topBar,
+    divider,
+    background,
+    children,
+    style,
+    touchableWithoutFeedbackDisabled,
+  } = props;
   const styles = useStyles(props);
   const theme = useTheme();
   const statusBarVariant = theme.dark ? 'light-content' : 'dark-content';
@@ -47,22 +67,27 @@ const StyledSafeAreaView: React.FC<StyledSafeAreaViewProps> = (props) => {
       )}
       {topBar}
       {divider && <Divider />}
-      <View style={[styles.content, style]}>
-        {scrollable ? (
-          <View style={styles.scrollViewContainer} onStartShouldSetResponder={() => false}>
-            <ScrollView
-              style={{ margin: -theme.spacing.m }}
-              contentContainerStyle={{ padding: theme.spacing.m }}
-            >
+      <TouchableWithoutFeedback
+        disabled={touchableWithoutFeedbackDisabled ?? true}
+        onPress={Keyboard.dismiss}
+      >
+        <View style={[styles.content, style]}>
+          {scrollable ? (
+            <View style={styles.scrollViewContainer} onStartShouldSetResponder={() => false}>
+              <ScrollView
+                style={{ margin: -theme.spacing.m }}
+                contentContainerStyle={{ padding: theme.spacing.m }}
+              >
+                {children}
+              </ScrollView>
+            </View>
+          ) : (
+            <View style={{ flex: 1 }} onStartShouldSetResponder={() => false}>
               {children}
-            </ScrollView>
-          </View>
-        ) : (
-          <View style={{ flex: 1 }} onStartShouldSetResponder={() => false}>
-            {children}
-          </View>
-        )}
-      </View>
+            </View>
+          )}
+        </View>
+      </TouchableWithoutFeedback>
     </View>
   );
 };

--- a/src/screens/CheckWalletPassword/index.tsx
+++ b/src/screens/CheckWalletPassword/index.tsx
@@ -95,6 +95,7 @@ const CheckWalletPassword = (props: NavProps) => {
     <StyledSafeAreaView
       style={styles.root}
       topBar={<TopBar stackProps={props} title={t('confirm password')} />}
+      touchableWithoutFeedbackDisabled={false}
     >
       <View style={styles.passwordLabel}>
         <Typography.Body>{t('enter security password')}</Typography.Body>

--- a/src/screens/CreateWalletPassword/index.tsx
+++ b/src/screens/CreateWalletPassword/index.tsx
@@ -42,7 +42,11 @@ const CreateWalletPassword = (props: NavProps) => {
   }, [navigation, password, route.params.account]);
 
   return (
-    <StyledSafeAreaView style={styles.root} topBar={<TopBar stackProps={props} />}>
+    <StyledSafeAreaView
+      style={styles.root}
+      topBar={<TopBar stackProps={props} />}
+      touchableWithoutFeedbackDisabled={false}
+    >
       <Typography.Title>{t('create password')}</Typography.Title>
       <Typography.Body>{t('add an extra security')}</Typography.Body>
       <View style={styles.passwordLabel}>

--- a/src/screens/EditProfile/index.tsx
+++ b/src/screens/EditProfile/index.tsx
@@ -181,6 +181,7 @@ const EditProfile = () => {
           title={profile ? t('edit profile') : t('create profile')}
         />
       }
+      touchableWithoutFeedbackDisabled={false}
     >
       <KeyboardAvoidingView
         keyboardVerticalOffset={Platform.OS === 'ios' ? 110 : 0}

--- a/src/screens/ImportAccountFromMnemonic/index.tsx
+++ b/src/screens/ImportAccountFromMnemonic/index.tsx
@@ -93,7 +93,11 @@ const ImportAccountFromMnemonic: FC<NavProps> = (props) => {
   };
 
   return (
-    <StyledSafeAreaView style={styles.root} topBar={<TopBar stackProps={props} />}>
+    <StyledSafeAreaView
+      style={styles.root}
+      topBar={<TopBar stackProps={props} />}
+      touchableWithoutFeedbackDisabled={false}
+    >
       <Typography.Title>{t('import recovery passphrase')}</Typography.Title>
       <Typography.Body>{t('enter recovery passphrase')}.</Typography.Body>
 

--- a/src/screens/ScanQr/index.tsx
+++ b/src/screens/ScanQr/index.tsx
@@ -82,7 +82,7 @@ const ScanQr: React.FC<NavProps> = ({ navigation }) => {
   );
 
   return (
-    <StyledSafeAreaView style={styles.root} padding={0}>
+    <StyledSafeAreaView style={styles.root} padding={0} touchableWithoutFeedbackDisabled={false}>
       <IconButton style={styles.backButton} icon="close" size={18} onPress={goBack} />
       <QrCodeScanner onQrCodeDetected={onQrCodeDetected} stopRecognition={pairing} />
       {__DEV__ && (

--- a/src/screens/SelectAccount/components/AccountPicker/index.tsx
+++ b/src/screens/SelectAccount/components/AccountPicker/index.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StyleProp, View, ViewStyle } from 'react-native';
 import Typography from 'components/Typography';
-import ListItemSeparator from 'components/ListItemSeparator';
 import { HdPath } from '@cosmjs/crypto';
 import {
   useFetchWallets,
@@ -70,15 +69,18 @@ const AccountPicker: React.FC<AccountPickerProps> = ({ onAccountSelected, params
     (info: ListRenderItemInfo<AccountWithWallet>) => {
       const { address } = info.item.account;
       return (
-        <AccountListItem
-          address={address}
-          highlight={selectedAccount?.account.address === address}
-          onPress={() => {
-            const account = selectedAccount?.account.address === address ? null : info.item;
-            setSelectedAccount(account);
-            onAccountSelected(account);
-          }}
-        />
+        <>
+          <AccountListItem
+            address={address}
+            highlight={selectedAccount?.account.address === address}
+            onPress={() => {
+              const account = selectedAccount?.account.address === address ? null : info.item;
+              setSelectedAccount(account);
+              onAccountSelected(account);
+            }}
+          />
+          <View style={styles.separator} />
+        </>
       );
     },
     [selectedAccount, onAccountSelected, setSelectedAccount],
@@ -108,7 +110,6 @@ const AccountPicker: React.FC<AccountPickerProps> = ({ onAccountSelected, params
           renderItem={renderListItem}
           keyExtractor={listKeyExtractor}
           onEndReachedThreshold={0.5}
-          ItemSeparatorComponent={ListItemSeparator}
           estimatedItemSize={74}
         />
       ) : null}

--- a/src/screens/SelectAccount/components/AccountPicker/useStyles.ts
+++ b/src/screens/SelectAccount/components/AccountPicker/useStyles.ts
@@ -45,6 +45,9 @@ const useStyles = makeStyle((theme) => ({
   disabledText: {
     color: theme.colors.disabled,
   },
+  separator: {
+    paddingVertical: theme.spacing.s,
+  },
 }));
 
 export default useStyles;

--- a/src/screens/SelectAccount/components/PaginatedFlatList/index.tsx
+++ b/src/screens/SelectAccount/components/PaginatedFlatList/index.tsx
@@ -5,6 +5,7 @@ import {
   FlashListProps,
   ListRenderItemInfo as FlashListRenderItemInfo,
 } from '@shopify/flash-list';
+import { useTheme } from 'react-native-paper';
 
 export type ListRenderItemInfo<T> = FlashListRenderItemInfo<T>;
 
@@ -26,6 +27,7 @@ const PaginatedFlatList = (props: PaginatedFlashListProps<any>) => {
   const [loading, setLoading] = useState(false);
   const [currentOffset, setCurrentOffset] = useState(0);
   const [data, setData] = useState<any[]>([]);
+  const theme = useTheme();
 
   const fetchNextPage = useCallback(async () => {
     setLoading(true);
@@ -77,7 +79,12 @@ const PaginatedFlatList = (props: PaginatedFlashListProps<any>) => {
       data={data}
       onEndReached={onPageEndReached}
       ListFooterComponent={
-        <StyledActivityIndicator animating={loading} hidesWhenStopped size="small" />
+        <StyledActivityIndicator
+          style={{ paddingBottom: theme.spacing.s }}
+          animating={loading}
+          hidesWhenStopped
+          size="small"
+        />
       }
     />
   );

--- a/src/screens/SelectAccount/index.tsx
+++ b/src/screens/SelectAccount/index.tsx
@@ -46,7 +46,11 @@ const SelectAccount: FC<NavProps> = (props) => {
   );
 
   return (
-    <StyledSafeAreaView style={styles.root} topBar={<TopBar stackProps={props} />}>
+    <StyledSafeAreaView
+      style={styles.root}
+      topBar={<TopBar stackProps={props} />}
+      touchableWithoutFeedbackDisabled={false}
+    >
       <Typography.Title>{t('import account')}</Typography.Title>
       <Typography.Body>{t('select account or enter derivation path')}.</Typography.Body>
 

--- a/src/screens/SendTokens/index.tsx
+++ b/src/screens/SendTokens/index.tsx
@@ -82,7 +82,10 @@ const SendTokens = () => {
   }, [address, amount, memo, sendTokens]);
 
   return (
-    <StyledSafeAreaView topBar={<TopBar stackProps={{ navigation }} title={t('send')} />}>
+    <StyledSafeAreaView
+      topBar={<TopBar stackProps={{ navigation }} title={t('send')} />}
+      touchableWithoutFeedbackDisabled={false}
+    >
       {/* Address */}
       <Typography.Subtitle>{t('recipient address')}</Typography.Subtitle>
       <TextInput

--- a/src/screens/SettingsChangeWalletPassword/index.tsx
+++ b/src/screens/SettingsChangeWalletPassword/index.tsx
@@ -67,6 +67,7 @@ const SettingsChangeWalletPassword = (props: NavProps) => {
     <StyledSafeAreaView
       style={styles.root}
       topBar={<TopBar stackProps={props} title={t('change password')} />}
+      touchableWithoutFeedbackDisabled={false}
     >
       {/* Description */}
       <Typography.Body>{t('change application password description')}</Typography.Body>

--- a/src/screens/SettingsEnableBiometricsAuthorization/index.tsx
+++ b/src/screens/SettingsEnableBiometricsAuthorization/index.tsx
@@ -73,7 +73,11 @@ const SettingsEnableBiometricsAuthorization: React.FC<Props> = (props) => {
   );
 
   return (
-    <StyledSafeAreaView style={styles.root} topBar={<TopBar stackProps={props} />}>
+    <StyledSafeAreaView
+      style={styles.root}
+      topBar={<TopBar stackProps={props} />}
+      touchableWithoutFeedbackDisabled={false}
+    >
       <Typography.Title>
         {biometricsType === BiometricAuthorizations.Login
           ? t('enable biometrics for login')

--- a/src/screens/UnlockApplication/index.tsx
+++ b/src/screens/UnlockApplication/index.tsx
@@ -114,6 +114,7 @@ const UnlockApplication: React.FC<NavProps> = (props) => {
   return (
     <StyledSafeAreaView
       topBar={<TopBar stackProps={props} hideGoBack={true} title={t('unlock application')} />}
+      touchableWithoutFeedbackDisabled={false}
     >
       <Typography.Subtitle>{t('enter security password')}</Typography.Subtitle>
       <SecureTextInput
@@ -127,7 +128,7 @@ const UnlockApplication: React.FC<NavProps> = (props) => {
       <Typography.Body style={styles.errorMsg}>{error}</Typography.Body>
       <Padding flex={1} />
       <KeyboardAvoidingView
-        keyboardVerticalOffset={Platform.OS === 'ios' ? bottom + 80 : 0}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? bottom + 100 : 0}
         {...(Platform.OS === 'ios' ? { behavior: 'padding' } : {})}
       >
         <Button mode="contained" onPress={unlockWithPassword} loading={loading} disabled={loading}>


### PR DESCRIPTION
## Added a TouchableWithoutFeedback to close the keyboard on iOS + UI fixes

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

- Added a new `TouchableWithoutFeedback` to close the KB when the user click outside the KB. Wherever there is a `TextInput` a new prop called `touchableWithoutFeedbackDisabled={true}` must be passed to the `StyledSafeAreaView`
- Fixed the Avatar loading style and the item separators style

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
