### PR TITLE
feat: improve app password creation screen

### DIFF
--- a/src/screens/CreateWalletPassword/index.tsx
+++ b/src/screens/CreateWalletPassword/index.tsx
@@ -1,7 +1,7 @@
 import { StackScreenProps } from '@react-navigation/stack';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { KeyboardAvoidingView, Platform, View } from 'react-native';
+import { KeyboardAvoidingView, Platform, TextInput, View } from 'react-native';
 import SecureTextInput from 'components/SecureTextInput';
 import Typography from 'components/Typography';
 import evaluatePasswordComplexity from 'hooks/useEvaluatePasswordComplexity';
@@ -11,6 +11,7 @@ import Button from 'components/Button';
 import { RootNavigatorParamList } from 'navigation/RootNavigator';
 import ROUTES from 'navigation/routes';
 import { AccountWithWallet } from 'types/account';
+import Spacer from 'components/Spacer';
 import PasswordComplexityScore from './components/PasswordComplexityScore';
 import useStyles from './useStyles';
 
@@ -27,27 +28,42 @@ const CreateWalletPassword = (props: NavProps) => {
   const { navigation, route } = props;
 
   const [password, setPassword] = useState('');
+  const confirmationPasswordRef = useRef<TextInput>(null);
+  const [confirmationPassword, setConfirmationPassword] = useState('');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const onPasswordChange = (text: string) => {
+  const onPasswordChange = useCallback((text: string) => {
     setPassword(text);
     setErrorMessage(null);
-  };
+  }, []);
+
+  const onConfirmationPasswordChanged = useCallback((text: string) => {
+    setConfirmationPassword(text);
+    setErrorMessage(null);
+  }, []);
+
+  const focusConfirmationPassword = useCallback(() => {
+    confirmationPasswordRef.current?.focus();
+  }, []);
 
   const onContinuePressed = useCallback(async () => {
-    navigation.navigate(ROUTES.CHECK_WALLET_PASSWORD, {
-      password,
-      account: route.params.account,
-    });
-  }, [navigation, password, route.params.account]);
+    if (password === confirmationPassword) {
+      navigation.navigate(ROUTES.SAVE_GENERATED_ACCOUNT, {
+        password,
+        account: route.params.account,
+      });
+    } else {
+      setErrorMessage(t('wrong confirmation password'));
+    }
+  }, [confirmationPassword, password, navigation, route.params?.account, t]);
 
   return (
     <StyledSafeAreaView
       style={styles.root}
-      topBar={<TopBar stackProps={props} />}
+      topBar={<TopBar stackProps={props} title={t('create password')} />}
       touchableWithoutFeedbackDisabled={false}
     >
-      <Typography.Title>{t('create password')}</Typography.Title>
+      {/* Password */}
       <Typography.Body>{t('add an extra security')}</Typography.Body>
       <View style={styles.passwordLabel}>
         <Typography.Body>{t('enter security password')}</Typography.Body>
@@ -58,12 +74,26 @@ const CreateWalletPassword = (props: NavProps) => {
         style={styles.password}
         value={password}
         onChangeText={onPasswordChange}
-        onSubmitEditing={onContinuePressed}
+        onSubmitEditing={focusConfirmationPassword}
         autoFocus
       />
       <Typography.Body style={styles.passwordComplexityHint}>
         {t('password complexity hint')}.
       </Typography.Body>
+
+      <Spacer paddingVertical={8} />
+
+      {/* Confirmation password */}
+      <Typography.Body>{t('confirm password')}</Typography.Body>
+      <SecureTextInput
+        inputRef={confirmationPasswordRef}
+        placeholder={t('confirm password')}
+        style={styles.password}
+        value={confirmationPassword}
+        onChangeText={onConfirmationPasswordChanged}
+        onSubmitEditing={onContinuePressed}
+      />
+
       <Typography.Body style={styles.errorParagraph}>{errorMessage}</Typography.Body>
       <KeyboardAvoidingView
         keyboardVerticalOffset={Platform.OS === 'ios' ? 110 : 0}


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR changes the `CreateWalletPassword` screen adding a second input that let the user confirm the password without navigating to the `CheckWalletPassword` screen.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
