### PR TITLE
feat: add a divider around "or login with" label in landing page

### DIFF
--- a/src/screens/Landing/index.tsx
+++ b/src/screens/Landing/index.tsx
@@ -143,9 +143,15 @@ const Landing = ({ navigation }: NavProps) => {
 
           <Spacer paddingVertical={12} />
 
-          <Typography.Subtitle style={styles.loginWithLabel}>
-            {t('or login with')}
-          </Typography.Subtitle>
+          <View style={styles.loginWithContainer}>
+            <View style={styles.loginDivider} />
+            <Spacer paddingHorizontal={8} />
+            <Typography.Subtitle style={styles.loginWithLabel}>
+              {t('or login with')}
+            </Typography.Subtitle>
+            <Spacer paddingHorizontal={8} />
+            <View style={styles.loginDivider} />
+          </View>
 
           <Spacer paddingVertical={8} />
 

--- a/src/screens/Landing/useStyles.ts
+++ b/src/screens/Landing/useStyles.ts
@@ -37,9 +37,19 @@ const useStyle = makeStyle((theme) => ({
   buttons: {
     justifyContent: 'center',
   },
+  loginWithContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    width: '100%',
+  },
   loginWithLabel: {
     color: '#ffffff',
-    alignSelf: 'center',
+  },
+  loginDivider: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+    height: 1,
   },
   socialButtonsContainer: {
     display: 'flex',


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR updates the UI of the landing page adding a divider around the "Or login with" text.  

Previous Landing:
![dpm_old_landing](https://user-images.githubusercontent.com/6245917/216989090-9979318a-a4eb-47c9-9554-9add2a43406b.jpeg)
New Landing:  
![dpm_new_landing](https://user-images.githubusercontent.com/6245917/216989127-43c86a0f-4691-4fd1-bbc2-726548ecce3f.jpeg)

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
