### PR TITLE
fix: fix mnemonic sanitization logic

### DIFF
--- a/src/lib/FormatUtils/index.ts
+++ b/src/lib/FormatUtils/index.ts
@@ -85,8 +85,18 @@ export const formatMultiSendInput = (inputs: Input[], separator: string = '\n'):
 /**
  * Perform the sanitization to a seed phrase.
  * @param mnemonic - The seed phrase to sanitize.
+ * @param skipTrimEnd - Tells if shouldn't be removed the whitespace chars from the
+ * end of the string.
  */
-export const sanitizeMnemonic = (mnemonic: string): string => mnemonic.replace(/\n\n/g, ' ').trim();
+export const sanitizeMnemonic = (mnemonic: string, skipTrimEnd?: boolean): string => {
+  // Replace the double spaces with a single space and
+  // remove all the characters that are not a-z or space.
+  const sanitized = mnemonic.replace(/( {2,})/gm, ' ').replace(/[^a-z ]/gm, '');
+  if (skipTrimEnd === true) {
+    return sanitized;
+  }
+  return sanitized.trimEnd();
+};
 
 /**
  * Converts a [Slip10RawIndex] to it's base number representation.

--- a/src/screens/ImportAccountFromMnemonic/index.tsx
+++ b/src/screens/ImportAccountFromMnemonic/index.tsx
@@ -37,15 +37,9 @@ const ImportAccountFromMnemonic: FC<NavProps> = (props) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const onMnemonicChange = (changedMnemonic: string) => {
-    const sanitizedMnemonic = sanitizeMnemonic(changedMnemonic);
-
-    // Handle enter pressed
-    if (sanitizedMnemonic.indexOf('\n') > 0) {
-      onNextPressed();
-    } else {
-      setMnemonic(sanitizedMnemonic);
-      setErrorMessage(null);
-    }
+    const sanitizedMnemonic = sanitizeMnemonic(changedMnemonic, true);
+    setMnemonic(sanitizedMnemonic);
+    setErrorMessage(null);
   };
 
   const onNextPressed = useCallback(async () => {
@@ -105,11 +99,14 @@ const ImportAccountFromMnemonic: FC<NavProps> = (props) => {
       </Typography.Body>
       <TextInput
         style={styles.mnemonicInput}
+        textAlignVertical={'top'}
         placeholder={t('enter recovery passphrase placeholder')}
         value={mnemonic}
         multiline
         onChangeText={onMnemonicChange}
+        blurOnSubmit
         autoFocus
+        onSubmitEditing={onNextPressed}
       />
 
       {errorMessage !== null && (


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR fixes the mnemonic sanitization logic in the `ImportAccountFromMnemonic`.  
Before the mnemonic input was sanitizing the text removing the ending spaces and so previnting the user to properly type the menemonic.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
