### PR TITLE
fix: fix WalletConnect expired sessions not being removed

### DIFF
--- a/src/hooks/walletconnect/useInitWalletConnectClient.ts
+++ b/src/hooks/walletconnect/useInitWalletConnectClient.ts
@@ -8,6 +8,7 @@ import { WALLET_CONNECT_PROJECT_ID } from '@env';
 
 import * as WalletConnectMMKV from 'lib/MMKVStorage/walletconnect';
 import { useRemoveSessionByTopic, useWalletConnectSessions } from '@recoil/walletConnectSessions';
+import useWalletConnectOnSessionExpire from './useWalletConnectOnSessionExpire';
 import useWalletConnectOnSessionRequest from './useWalletConnectOnSessionRequest';
 import useWalletConnectOnSessionDelete from './useWalletConnectOnSessionDelete';
 
@@ -16,6 +17,7 @@ const useInitWalletConnectClient = () => {
   const client = useWalletConnectClient();
   const onSessionRequest = useWalletConnectOnSessionRequest(client?.client);
   const onSessionDelete = useWalletConnectOnSessionDelete();
+  const onSessionExpire = useWalletConnectOnSessionExpire();
   const deleteSessionByTopic = useRemoveSessionByTopic();
   const savedSessions = useWalletConnectSessions();
 
@@ -36,6 +38,14 @@ const useInitWalletConnectClient = () => {
       client?.client.off('session_delete', onSessionDelete);
     };
   }, [onSessionDelete, client]);
+
+  // Effect to subscribe and unsubscribe to session_expire
+  useEffect(() => {
+    client?.client.on('session_expire', onSessionExpire);
+    return () => {
+      client?.client.off('session_expire', onSessionExpire);
+    };
+  }, [onSessionExpire, client]);
 
   return useCallback(async () => {
     try {

--- a/src/hooks/walletconnect/useWalletConnectOnSessionExpire.ts
+++ b/src/hooks/walletconnect/useWalletConnectOnSessionExpire.ts
@@ -1,0 +1,15 @@
+import { useRemoveSessionByTopic } from '@recoil/walletConnectSessions';
+import { useCallback } from 'react';
+import { SignClientTypes } from '@walletconnect/types';
+
+const useWalletConnectOnSessionExpire = () => {
+  const removeSessionByTopic = useRemoveSessionByTopic();
+  return useCallback(
+    (args: SignClientTypes.EventArguments['session_expire']) => {
+      removeSessionByTopic(args.topic);
+    },
+    [removeSessionByTopic],
+  );
+};
+
+export default useWalletConnectOnSessionExpire;


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR fixes the a bug that cause the application to not remove the expired WalletConnect sessions.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
