### PR TITLE
fix: fix null handling in MMKV serialization/deserialization

### DIFF
--- a/src/lib/MMKVStorage/encoding/index.ts
+++ b/src/lib/MMKVStorage/encoding/index.ts
@@ -21,7 +21,7 @@ function jsonReplacer(key: string, value: any): any {
  * Custom JSON deserialization for MMKV.
  */
 const jsonReviver = (key: string, value: any) => {
-  if (value[0] === '{') {
+  if (value !== null && value !== undefined && value[0] === '{') {
     // We have a serialized object, try to deserialize it to see if it's one
     // of our custom serialized types.
     const deserializedObject = <Partial<SerializedObject>>JSON.parse(value);

--- a/src/lib/MMKVStorage/encoding/serializers/date.ts
+++ b/src/lib/MMKVStorage/encoding/serializers/date.ts
@@ -2,7 +2,7 @@ import { SerializableTypes, SerializedObject, Serializer } from '../types';
 
 export const DateSerializer: Serializer = {
   canEncodeObj(obj: any): boolean {
-    return typeof obj.toISOString === 'function';
+    return typeof obj?.toISOString === 'function';
   },
   encode(obj: any): SerializedObject {
     return {

--- a/src/lib/MMKVStorage/index.test.ts
+++ b/src/lib/MMKVStorage/index.test.ts
@@ -1,6 +1,14 @@
 import { getMMKV, MMKVKEYS, setMMKV } from 'lib/MMKVStorage/index';
 
 describe('MMKV custom serialization', () => {
+  it('test serialize null value', () => {
+    const testData = { test: null };
+    setMMKV(MMKVKEYS.PROFILES, testData);
+    const reloadedDate = <typeof testData>getMMKV(MMKVKEYS.PROFILES);
+
+    expect(testData).toEqual(reloadedDate);
+  });
+
   it('test Date serialization', () => {
     const testDate = new Date();
     setMMKV(MMKVKEYS.PROFILES, testDate);


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR fixes the wrong handling of `null` data when serializing the data begin saved inside MMKV.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
