### PR TITLE
chore: fix linting error related to i18next

### DIFF
--- a/src/assets/locales/config.ts
+++ b/src/assets/locales/config.ts
@@ -1,0 +1,7 @@
+import en from 'assets/locales/en';
+
+export const defaultNS = 'common';
+export const resources = {
+  en,
+};
+export const nameSpaces = Object.keys(en);

--- a/src/assets/locales/i18n.ts
+++ b/src/assets/locales/i18n.ts
@@ -1,18 +1,17 @@
 import i18next from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import en from './en';
+import { defaultNS, nameSpaces, resources } from './config';
 
 i18next
   .use(initReactI18next)
   .init({
     fallbackLng: 'en',
     lng: 'en',
-    defaultNS: 'common',
+    defaultNS,
     keySeparator: 'false',
-    ns: [...Object.keys(en)],
-    resources: {
-      en,
-    },
+    returnNull: false,
+    ns: nameSpaces,
+    resources,
     interpolation: {
       escapeValue: false,
     },

--- a/src/assets/locales/i18next.d.ts
+++ b/src/assets/locales/i18next.d.ts
@@ -1,0 +1,12 @@
+// import the original type declarations
+import 'i18next';
+import { defaultNS, resources } from './config';
+
+// i18next module type definitions.
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: typeof defaultNS;
+    resources: typeof resources['en'];
+    returnNull: false;
+  }
+}


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR fixes the linting error related to `i18next` by updating the Typescript type defintions removing the possibility of receiving a `null` value when calling the `t` function to get the localized text.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
