### PR TITLE
feat: improve Legder account generation speed

### DIFF
--- a/src/components/Button/useStyles.ts
+++ b/src/components/Button/useStyles.ts
@@ -4,6 +4,16 @@ import ButtonProps from './props';
 const useStyles = makeStyleWithProps((props: ButtonProps, theme) => {
   const accent = props.accent ? theme.colors.accent : theme.colors.primary;
   const color = props.color ? props.color : accent;
+
+  let labelColor = props.mode === 'contained' ? theme.colors.font['5'] : color;
+  let borderColor = color;
+  if (props.disabled) {
+    borderColor = theme.colors.font['3'];
+    if (props.mode !== 'contained') {
+      labelColor = theme.colors.font['3'];
+    }
+  }
+
   return {
     labelStyle: {
       fontFamily: 'Poppins-Medium',
@@ -12,11 +22,11 @@ const useStyles = makeStyleWithProps((props: ButtonProps, theme) => {
       fontSize: 16,
       lineHeight: 24,
       letterSpacing: 0.0125,
-      color: props.mode === 'contained' ? theme.colors.font['5'] : color,
+      color: labelColor,
       textTransform: 'capitalize',
     },
     btnStyle: {
-      borderColor: color,
+      borderColor,
       borderWidth: props.mode === 'outlined' ? 1 : 0,
       elevation: 0,
     },

--- a/src/screens/SelectAccount/components/AccountPicker/index.tsx
+++ b/src/screens/SelectAccount/components/AccountPicker/index.tsx
@@ -40,6 +40,7 @@ const AccountPicker: React.FC<AccountPickerProps> = ({ onAccountSelected, params
     }
     return undefined;
   }, [params]);
+  const [toggleAddressPickerDisabled, setToggleAddressPickerDisabled] = useState(true);
   const [selectedHdPath, setSelectedHdPath] = useState<HdPath | undefined>(masterHdPath);
   const [selectedAccount, setSelectedAccount] = useState<AccountWithWallet | null>(null);
   const [addressPickerVisible, setAddressPickerVisible] = useState(true);
@@ -114,6 +115,7 @@ const AccountPicker: React.FC<AccountPickerProps> = ({ onAccountSelected, params
         <PaginatedFlatList
           extraData={selectedAccount}
           loadPage={fetchWallets}
+          onLoadStateChange={setToggleAddressPickerDisabled}
           itemsPerPage={10}
           renderItem={renderListItem}
           keyExtractor={listKeyExtractor}
@@ -126,6 +128,7 @@ const AccountPicker: React.FC<AccountPickerProps> = ({ onAccountSelected, params
 
       {masterHdPath !== undefined && (
         <Button
+          disabled={toggleAddressPickerDisabled}
           mode="text"
           onPress={toggleAddressPicker}
           labelStyle={styles.pickerOptionButtonLabel}

--- a/src/screens/SelectAccount/components/AccountPicker/index.tsx
+++ b/src/screens/SelectAccount/components/AccountPicker/index.tsx
@@ -114,10 +114,10 @@ const AccountPicker: React.FC<AccountPickerProps> = ({ onAccountSelected, params
         <PaginatedFlatList
           extraData={selectedAccount}
           loadPage={fetchWallets}
-          itemsPerPage={15}
+          itemsPerPage={10}
           renderItem={renderListItem}
           keyExtractor={listKeyExtractor}
-          onEndReachedThreshold={0.5}
+          onEndReachedThreshold={0.2}
           estimatedItemSize={89}
         />
       ) : null}

--- a/src/screens/SelectAccount/components/PaginatedFlatList/index.tsx
+++ b/src/screens/SelectAccount/components/PaginatedFlatList/index.tsx
@@ -20,17 +20,30 @@ export type PaginatedFlashListProps<ItemT> = Omit<FlashListProps<ItemT>, 'data'>
    * Amount of items to load when the list reach the end.
    */
   itemsPerPage: number;
+
+  /**
+   * Callback called when the loading state changes.
+   */
+  onLoadStateChange?: (loading: boolean) => any;
 };
 
 const PaginatedFlatList = (props: PaginatedFlashListProps<any>) => {
-  const { loadPage, itemsPerPage, onEndReached } = props;
+  const { loadPage, itemsPerPage, onEndReached, onLoadStateChange } = props;
   const [loading, setLoading] = useState(false);
   const [currentOffset, setCurrentOffset] = useState(0);
   const [data, setData] = useState<any[]>([]);
   const theme = useTheme();
 
+  const setLoadingState = useCallback(
+    (l: boolean) => {
+      if (onLoadStateChange) onLoadStateChange(l);
+      setLoading(l);
+    },
+    [onLoadStateChange],
+  );
+
   const fetchNextPage = useCallback(async () => {
-    setLoading(true);
+    setLoadingState(true);
     const fetched: any[] = [];
     let itemsAvailable = true;
     let offset = currentOffset;
@@ -51,8 +64,8 @@ const PaginatedFlatList = (props: PaginatedFlashListProps<any>) => {
       setData((current) => [...current, ...fetched]);
     }
     setCurrentOffset(offset);
-    setLoading(false);
-  }, [currentOffset, loadPage, itemsPerPage]);
+    setLoadingState(false);
+  }, [setLoadingState, currentOffset, itemsPerPage, loadPage]);
 
   const onPageEndReached = useCallback(() => {
     if (!loading) {

--- a/src/screens/SelectAccount/components/PaginatedFlatList/index.tsx
+++ b/src/screens/SelectAccount/components/PaginatedFlatList/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import StyledActivityIndicator from 'components/StyledActivityIndicator';
 import {
   FlashList,
@@ -62,16 +62,6 @@ const PaginatedFlatList = (props: PaginatedFlashListProps<any>) => {
       onEndReached();
     }
   }, [loading, onEndReached, fetchNextPage]);
-
-  useEffect(() => {
-    if (currentOffset === 0) {
-      fetchNextPage().then(() => {});
-    }
-
-    // Safe to ignore, since we need to fetch the first page when the component
-    // is ready.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <FlashList


### PR DESCRIPTION
## Description

Closes: #XXXX

This PR improves the loading speed when importing an account with the Ledger device.To achive this I have reduced the amount of accounts generated for each page from 15 to 10.
This PR fixes also a bug that couse a communication error with the Ledger if the user toggle the `HdPath` picker while the app is generating a page of accounts.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
