### PR TITLE
fix: allow user to re-insert wrong password during wallet unlock

### DIFF
--- a/src/assets/locales/en/account.json
+++ b/src/assets/locales/en/account.json
@@ -30,6 +30,7 @@
   "generating address": "Generating address",
   "import account": "Import account",
   "import recovery passphrase": "Import recovery passphrase",
+  "wrong password": "Password doesn't match",
   "invalid password": "Invalid password",
   "invalid words": "Invalid words",
   "no transactions": "No transactions",

--- a/src/assets/locales/en/settings.json
+++ b/src/assets/locales/en/settings.json
@@ -30,6 +30,5 @@
   "enable": "Enable",
   "insert your password to enable biometrics login": "Insert your password to allow login into the app with biometrics",
   "insert your password to enable biometrics signature": "Insert your password to allow to confirm transactions signature with biometrics",
-  "wrong password": "Password doesn't match",
   "unlock application": "Unlock application"
 }

--- a/src/lib/SecureStorage/errors.ts
+++ b/src/lib/SecureStorage/errors.ts
@@ -1,0 +1,74 @@
+// Suppress lint error to keep all the SecureStorage related errors in on file.
+/* eslint-disable max-classes-per-file */
+
+export enum SecureStoreErrorType {
+  InvalidPassword = 'SecureStorageErrorInvalidPassword',
+  EncryptionFailed = 'SecureStorageErrorEncryptionFailed',
+  CorruptedData = 'SecureStorageErrorCorruptedData',
+  WalletNotFound = 'SecureStorageErrorWalletNotFound',
+  UnknownError = 'SecureStorageErrorUnknownError',
+}
+
+export class InvalidPasswordError extends Error {
+  constructor() {
+    super();
+    this.name = SecureStoreErrorType.InvalidPassword;
+  }
+}
+
+export class EncryptionFailedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = SecureStoreErrorType.EncryptionFailed;
+  }
+}
+
+export class CorruptedDataError extends Error {
+  constructor() {
+    super();
+    this.name = SecureStoreErrorType.CorruptedData;
+  }
+}
+
+export class WalletNotFoundError extends Error {
+  readonly address: string;
+
+  constructor(address: string) {
+    super(`Wallet with address ${address} not found`);
+    this.address = address;
+    this.name = SecureStoreErrorType.WalletNotFound;
+  }
+}
+
+export class UnknownSecureStorageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = SecureStoreErrorType.UnknownError;
+  }
+}
+
+export type SecureStorageError =
+  | InvalidPasswordError
+  | CorruptedDataError
+  | WalletNotFoundError
+  | UnknownSecureStorageError;
+
+export function isInvalidPasswordError(error: Error): error is InvalidPasswordError {
+  return error.name === SecureStoreErrorType.InvalidPassword;
+}
+
+export function isEncryptionFailedError(error: Error): error is EncryptionFailedError {
+  return error.name === SecureStoreErrorType.EncryptionFailed;
+}
+
+export function isCorruptedDataError(error: Error): error is CorruptedDataError {
+  return error.name === SecureStoreErrorType.CorruptedData;
+}
+
+export function isWalletNotFoundError(error: Error): error is WalletNotFoundError {
+  return error.name === SecureStoreErrorType.WalletNotFound;
+}
+
+export function isUnknownSecureStorageError(error: Error): error is UnknownSecureStorageError {
+  return error.name === SecureStoreErrorType.UnknownError;
+}

--- a/src/screens/SettingsChangeWalletPassword/index.tsx
+++ b/src/screens/SettingsChangeWalletPassword/index.tsx
@@ -73,7 +73,7 @@ const SettingsChangeWalletPassword = (props: NavProps) => {
   const onContinue = useCallback(async () => {
     const success = await changePassword(oldPassword, newPassword);
     if (!success) {
-      setOldPasswordError(t('common:invalid password'));
+      setOldPasswordError(t('account:invalid password'));
       return;
     }
 

--- a/src/screens/UnlockApplication/index.tsx
+++ b/src/screens/UnlockApplication/index.tsx
@@ -107,7 +107,7 @@ const UnlockApplication: React.FC<NavProps> = (props) => {
 
       const passwordOk = await checkUserPassword(password);
       if (!passwordOk) {
-        setError(t('invalid password'));
+        setError(t('account:wrong password'));
       } else if (previousScreenParams !== undefined) {
         // Go to the previous screen.
         navigation.navigate(previousScreenParams);

--- a/src/screens/UnlockWallet/index.tsx
+++ b/src/screens/UnlockWallet/index.tsx
@@ -17,6 +17,7 @@ import { SigningMode } from '@desmoslabs/desmjs';
 import { useSetting } from '@recoil/settings';
 import { BiometricAuthorizations } from 'types/settings';
 import useGetPasswordFromBiometrics from 'hooks/useGetPasswordFromBiometrics';
+import { isInvalidPasswordError } from 'lib/SecureStorage/errors';
 import useStyles from './useStyles';
 
 export interface UnlockWalletParams {
@@ -87,21 +88,19 @@ const UnlockWallet: React.FC<Props> = (props) => {
       // Unlock the wallet
       const result = await unlockWalletWithPassword(address, unlockWalletPassword, signingMode);
       if (result.isErr()) {
-        const { message } = result.error;
-        setError(message.indexOf('BAD_DECRYPT') !== 0 ? t('wrong password') : message);
-        return;
+        if (isInvalidPasswordError(result.error)) {
+          setError(t('wrong password'));
+        } else {
+          setError((result.error as Error).message);
+        }
+      } else {
+        const { value: wallet } = result;
+        if (wallet) {
+          // Connect the signer to be able to use the wallet
+          await wallet.signer.connect();
+          onSuccess(wallet);
+        }
       }
-
-      // Make sure the wallet is valid
-      const { value: wallet } = result;
-      if (!wallet) {
-        // The user has gone back (ie. when connecting to the Ledger), before completing the unlock
-        return;
-      }
-
-      // Connect the signer to be able to use the wallet
-      await wallet.signer.connect();
-      onSuccess(wallet);
       setLoading(false);
     },
     [unlockWalletWithPassword, address, signingMode, onSuccess, t],

--- a/src/screens/UnlockWallet/index.tsx
+++ b/src/screens/UnlockWallet/index.tsx
@@ -89,7 +89,7 @@ const UnlockWallet: React.FC<Props> = (props) => {
       const result = await unlockWalletWithPassword(address, unlockWalletPassword, signingMode);
       if (result.isErr()) {
         if (isInvalidPasswordError(result.error)) {
-          setError(t('wrong password'));
+          setError(t('account:wrong password'));
         } else {
           setError((result.error as Error).message);
         }


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR fixes a bug that prevents the wallet unlock if the user insert a wrong password.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
