### PR TITLE
feat: add support to x/reactions messages

### DIFF
--- a/src/assets/locales/en/messages/common.json
+++ b/src/assets/locales/en/messages/common.json
@@ -1,3 +1,4 @@
 {
-  "signer": "Signer"
+  "signer": "Signer",
+  "user": "User"
 }

--- a/src/assets/locales/en/messages/index.ts
+++ b/src/assets/locales/en/messages/index.ts
@@ -4,6 +4,7 @@ import common from './common.json';
 import gov from './gov.json';
 import posts from './posts.json';
 import profiles from './profiles.json';
+import reactions from './reactions.json';
 import staking from './staking.json';
 import subspaces from './subspaces.json';
 import feegrant from './feegrant.json';
@@ -16,6 +17,7 @@ const messages = {
   'messages.gov': gov,
   'messages.posts': posts,
   'messages.profiles': profiles,
+  'messages.reactions': reactions,
   'messages.staking': staking,
   'messages.subspaces': subspaces,
   'messages.feegrant': feegrant,

--- a/src/assets/locales/en/messages/reactions.json
+++ b/src/assets/locales/en/messages/reactions.json
@@ -4,10 +4,15 @@
   "add registered reaction": "Add registered reaction",
   "edit registered reaction": "Edit registered reaction",
   "remove registered reaction": "Remove registered reaction",
+  "set reactions params": "Set reactions params",
   "shorthand code": "Shorthand code",
   "display value": "Display value",
   "free text value reaction": "Free text value reaction",
   "registered reaction id": "Registered reaction id",
   "unsupported reaction value": "Unsupported reaction value",
-  "reaction id": "Reaction id"
+  "reaction id": "Reaction id",
+  "registered reactions enabled": "Registered reactions enabled",
+  "free text reactions enabled": "Free text reactions enabled",
+  "free text reactions max length": "Free text reactions max length",
+  "free text reactions regex": "Free text reactions regex"
 }

--- a/src/assets/locales/en/messages/reactions.json
+++ b/src/assets/locales/en/messages/reactions.json
@@ -2,6 +2,7 @@
   "add reaction": "Add reaction",
   "remove reaction": "Remove reaction",
   "add registered reaction": "Add registered reaction",
+  "edit registered reaction": "Edit registered reaction",
   "shorthand code": "Shorthand code",
   "display value": "Display value",
   "free text value reaction": "Free text value reaction",

--- a/src/assets/locales/en/messages/reactions.json
+++ b/src/assets/locales/en/messages/reactions.json
@@ -3,6 +3,7 @@
   "remove reaction": "Remove reaction",
   "add registered reaction": "Add registered reaction",
   "edit registered reaction": "Edit registered reaction",
+  "remove registered reaction": "Remove registered reaction",
   "shorthand code": "Shorthand code",
   "display value": "Display value",
   "free text value reaction": "Free text value reaction",

--- a/src/assets/locales/en/messages/reactions.json
+++ b/src/assets/locales/en/messages/reactions.json
@@ -1,8 +1,10 @@
 {
   "add reaction": "Add reaction",
+  "remove reaction": "Remove reaction",
   "shorthand code": "Shorthand code",
   "display value": "Display value",
   "free text value reaction": "Free text value reaction",
   "registered reaction id": "Registered reaction id",
-  "unsupported reaction value": "Unsupported reaction value"
+  "unsupported reaction value": "Unsupported reaction value",
+  "reaction id": "Reaction id"
 }

--- a/src/assets/locales/en/messages/reactions.json
+++ b/src/assets/locales/en/messages/reactions.json
@@ -1,6 +1,7 @@
 {
   "add reaction": "Add reaction",
   "remove reaction": "Remove reaction",
+  "add registered reaction": "Add registered reaction",
   "shorthand code": "Shorthand code",
   "display value": "Display value",
   "free text value reaction": "Free text value reaction",

--- a/src/assets/locales/en/messages/reactions.json
+++ b/src/assets/locales/en/messages/reactions.json
@@ -1,0 +1,8 @@
+{
+  "add reaction": "Add reaction",
+  "shorthand code": "Shorthand code",
+  "display value": "Display value",
+  "free text value reaction": "Free text value reaction",
+  "registered reaction id": "Registered reaction id",
+  "unsupported reaction value": "Unsupported reaction value"
+}

--- a/src/components/Messages/components.ts
+++ b/src/components/Messages/components.ts
@@ -2,6 +2,7 @@ import {
   MsgAcceptDTagTransferRequestTypeUrl,
   MsgAddPostAttachmentTypeUrl,
   MsgAddReactionTypeUrl,
+  MsgAddRegisteredReactionTypeUrl,
   MsgAddUserToUserGroupTypeUrl,
   MsgAnswerPollTypeUrl,
   MsgBlockUserTypeUrl,
@@ -93,6 +94,7 @@ import MsgEditPostComponents from './posts/MsgEditPost';
 import MsgAddPostAttachmentComponents from './posts/MsgAddPostAttachment';
 import MsgAnswerPollComponents from './posts/MsgAnswerPoll';
 import MsgRemoveReactionComponents from './reactions/MsgRemoveReaction';
+import MsgAddRegisteredReactionComponents from './reactions/MsgAddRegisteredReaction';
 
 export const messageDetailsComponents: Record<string, MessageComponents<any>> = {
   // x/bank
@@ -160,4 +162,5 @@ export const messageDetailsComponents: Record<string, MessageComponents<any>> = 
   // x/reactions
   [MsgAddReactionTypeUrl]: MsgAddReactionComponents,
   [MsgRemoveReactionTypeUrl]: MsgRemoveReactionComponents,
+  [MsgAddRegisteredReactionTypeUrl]: MsgAddRegisteredReactionComponents,
 };

--- a/src/components/Messages/components.ts
+++ b/src/components/Messages/components.ts
@@ -34,6 +34,7 @@ import {
   MsgRefuseDTagTransferRequestTypeUrl,
   MsgRemovePostAttachmentTypeUrl,
   MsgRemoveReactionTypeUrl,
+  MsgRemoveRegisteredReactionTypeUrl,
   MsgRemoveUserFromUserGroupTypeUrl,
   MsgRequestDTagTransferTypeUrl,
   MsgRevokeAllowanceTypeUrl,
@@ -97,6 +98,7 @@ import MsgAnswerPollComponents from './posts/MsgAnswerPoll';
 import MsgRemoveReactionComponents from './reactions/MsgRemoveReaction';
 import MsgAddRegisteredReactionComponents from './reactions/MsgAddRegisteredReaction';
 import MsgEditRegisteredReactionComponents from './reactions/MsgEditRegisteredReaction';
+import MsgRemoveRegisteredReactionComponents from './reactions/MsgRemoveRegisteredReaction';
 
 export const messageDetailsComponents: Record<string, MessageComponents<any>> = {
   // x/bank
@@ -166,4 +168,5 @@ export const messageDetailsComponents: Record<string, MessageComponents<any>> = 
   [MsgRemoveReactionTypeUrl]: MsgRemoveReactionComponents,
   [MsgAddRegisteredReactionTypeUrl]: MsgAddRegisteredReactionComponents,
   [MsgEditRegisteredReactionTypeUrl]: MsgEditRegisteredReactionComponents,
+  [MsgRemoveRegisteredReactionTypeUrl]: MsgRemoveRegisteredReactionComponents,
 };

--- a/src/components/Messages/components.ts
+++ b/src/components/Messages/components.ts
@@ -31,6 +31,7 @@ import {
   MsgMultiSendTypeUrl,
   MsgRefuseDTagTransferRequestTypeUrl,
   MsgRemovePostAttachmentTypeUrl,
+  MsgRemoveReactionTypeUrl,
   MsgRemoveUserFromUserGroupTypeUrl,
   MsgRequestDTagTransferTypeUrl,
   MsgRevokeAllowanceTypeUrl,
@@ -91,6 +92,7 @@ import MsgDeletePostComponents from './posts/MsgDeletePost';
 import MsgEditPostComponents from './posts/MsgEditPost';
 import MsgAddPostAttachmentComponents from './posts/MsgAddPostAttachment';
 import MsgAnswerPollComponents from './posts/MsgAnswerPoll';
+import MsgRemoveReactionComponents from './reactions/MsgRemoveReaction';
 
 export const messageDetailsComponents: Record<string, MessageComponents<any>> = {
   // x/bank
@@ -157,4 +159,5 @@ export const messageDetailsComponents: Record<string, MessageComponents<any>> = 
 
   // x/reactions
   [MsgAddReactionTypeUrl]: MsgAddReactionComponents,
+  [MsgRemoveReactionTypeUrl]: MsgRemoveReactionComponents,
 };

--- a/src/components/Messages/components.ts
+++ b/src/components/Messages/components.ts
@@ -20,6 +20,7 @@ import {
   MsgDeleteSubspaceTypeUrl,
   MsgDeleteUserGroupTypeUrl,
   MsgEditPostTypeUrl,
+  MsgEditRegisteredReactionTypeUrl,
   MsgEditSectionTypeUrl,
   MsgEditSubspaceTypeUrl,
   MsgEditUserGroupTypeUrl,
@@ -95,6 +96,7 @@ import MsgAddPostAttachmentComponents from './posts/MsgAddPostAttachment';
 import MsgAnswerPollComponents from './posts/MsgAnswerPoll';
 import MsgRemoveReactionComponents from './reactions/MsgRemoveReaction';
 import MsgAddRegisteredReactionComponents from './reactions/MsgAddRegisteredReaction';
+import MsgEditRegisteredReactionComponents from './reactions/MsgEditRegisteredReaction';
 
 export const messageDetailsComponents: Record<string, MessageComponents<any>> = {
   // x/bank
@@ -163,4 +165,5 @@ export const messageDetailsComponents: Record<string, MessageComponents<any>> = 
   [MsgAddReactionTypeUrl]: MsgAddReactionComponents,
   [MsgRemoveReactionTypeUrl]: MsgRemoveReactionComponents,
   [MsgAddRegisteredReactionTypeUrl]: MsgAddRegisteredReactionComponents,
+  [MsgEditRegisteredReactionTypeUrl]: MsgEditRegisteredReactionComponents,
 };

--- a/src/components/Messages/components.ts
+++ b/src/components/Messages/components.ts
@@ -41,6 +41,7 @@ import {
   MsgRevokeTypeUrl,
   MsgSaveProfileTypeUrl,
   MsgSendTypeUrl,
+  MsgSetReactionsParamsTypeUrl,
   MsgSetUserGroupPermissionsTypeUrl,
   MsgSetUserPermissionsTypeUrl,
   MsgUnblockUserTypeUrl,
@@ -77,6 +78,7 @@ import MsgAddUserToUserGroupComponents from 'components/Messages/subspaces/MsgAd
 import MsgRemoveUserFromUserGroupComponents from 'components/Messages/subspaces/MsgRemoveUserFromUserGroup';
 import MsgRemovePostAttachmentComponents from 'components/Messages/posts/MsgRemovePostAttachment';
 import MsgAddReactionComponents from 'components/Messages/reactions/MsgAddReaction';
+import MsgSetReactionsParamsComponents from 'components/Messages/reactions/MsgSetReactionsParams';
 import { MessageComponents } from './BaseMessage';
 import MsgCancelDtagTransferRequestComponents from './MsgCancelDTagTransferRequest';
 import MsgCreateRelationshipComponents from './MsgCreateRelationship';
@@ -169,4 +171,5 @@ export const messageDetailsComponents: Record<string, MessageComponents<any>> = 
   [MsgAddRegisteredReactionTypeUrl]: MsgAddRegisteredReactionComponents,
   [MsgEditRegisteredReactionTypeUrl]: MsgEditRegisteredReactionComponents,
   [MsgRemoveRegisteredReactionTypeUrl]: MsgRemoveRegisteredReactionComponents,
+  [MsgSetReactionsParamsTypeUrl]: MsgSetReactionsParamsComponents,
 };

--- a/src/components/Messages/components.ts
+++ b/src/components/Messages/components.ts
@@ -1,6 +1,7 @@
 import {
   MsgAcceptDTagTransferRequestTypeUrl,
   MsgAddPostAttachmentTypeUrl,
+  MsgAddReactionTypeUrl,
   MsgAddUserToUserGroupTypeUrl,
   MsgAnswerPollTypeUrl,
   MsgBlockUserTypeUrl,
@@ -71,6 +72,7 @@ import MsgMoveUserGroupComponents from 'components/Messages/subspaces/MsgMoveUse
 import MsgAddUserToUserGroupComponents from 'components/Messages/subspaces/MsgAddUserToUserGroup';
 import MsgRemoveUserFromUserGroupComponents from 'components/Messages/subspaces/MsgRemoveUserFromUserGroup';
 import MsgRemovePostAttachmentComponents from 'components/Messages/posts/MsgRemovePostAttachment';
+import MsgAddReactionComponents from 'components/Messages/reactions/MsgAddReaction';
 import { MessageComponents } from './BaseMessage';
 import MsgCancelDtagTransferRequestComponents from './MsgCancelDTagTransferRequest';
 import MsgCreateRelationshipComponents from './MsgCreateRelationship';
@@ -152,4 +154,7 @@ export const messageDetailsComponents: Record<string, MessageComponents<any>> = 
   [MsgAddPostAttachmentTypeUrl]: MsgAddPostAttachmentComponents,
   [MsgRemovePostAttachmentTypeUrl]: MsgRemovePostAttachmentComponents,
   [MsgAnswerPollTypeUrl]: MsgAnswerPollComponents,
+
+  // x/reactions
+  [MsgAddReactionTypeUrl]: MsgAddReactionComponents,
 };

--- a/src/components/Messages/posts/MsgAddPostAttachment/MsgAddPostAttachmentDetails/index.tsx
+++ b/src/components/Messages/posts/MsgAddPostAttachment/MsgAddPostAttachmentDetails/index.tsx
@@ -10,7 +10,7 @@ import useGetGeneratePostAttachmentDetailFields from 'components/Messages/posts/
  * Displays the full details of a MsgAddPostAttachment
  * @constructor
  */
-const MsgEditSubspaceDetails: MessageDetailsComponent<MsgAddPostAttachmentEncodeObject> = ({
+const MsgAddPostAttachment: MessageDetailsComponent<MsgAddPostAttachmentEncodeObject> = ({
   message,
 }) => {
   const { t } = useTranslation('messages.posts');
@@ -45,4 +45,4 @@ const MsgEditSubspaceDetails: MessageDetailsComponent<MsgAddPostAttachmentEncode
   );
 };
 
-export default MsgEditSubspaceDetails;
+export default MsgAddPostAttachment;

--- a/src/components/Messages/posts/MsgAnswerPoll/MsgAnswerPollDetails/index.tsx
+++ b/src/components/Messages/posts/MsgAnswerPoll/MsgAnswerPollDetails/index.tsx
@@ -9,7 +9,7 @@ import { MessageDetailsComponent } from 'components/Messages/BaseMessage';
  * Displays the full details of a MsgAnswerPoll
  * @constructor
  */
-const MsgEditSubspaceDetails: MessageDetailsComponent<MsgAnswerPollEncodeObject> = ({
+const MsgAddPostAttachmentDetails: MessageDetailsComponent<MsgAnswerPollEncodeObject> = ({
   message,
 }) => {
   const { t } = useTranslation('messages.posts');
@@ -47,4 +47,4 @@ const MsgEditSubspaceDetails: MessageDetailsComponent<MsgAnswerPollEncodeObject>
   );
 };
 
-export default MsgEditSubspaceDetails;
+export default MsgAddPostAttachmentDetails;

--- a/src/components/Messages/posts/MsgAnswerPoll/MsgAnswerPollDetails/index.tsx
+++ b/src/components/Messages/posts/MsgAnswerPoll/MsgAnswerPollDetails/index.tsx
@@ -9,9 +9,7 @@ import { MessageDetailsComponent } from 'components/Messages/BaseMessage';
  * Displays the full details of a MsgAnswerPoll
  * @constructor
  */
-const MsgAddPostAttachmentDetails: MessageDetailsComponent<MsgAnswerPollEncodeObject> = ({
-  message,
-}) => {
+const MsgAnswerPollDetails: MessageDetailsComponent<MsgAnswerPollEncodeObject> = ({ message }) => {
   const { t } = useTranslation('messages.posts');
   const { t: tSubspaces } = useTranslation('messages.subspaces');
   const { t: tCommon } = useTranslation('messages.common');
@@ -47,4 +45,4 @@ const MsgAddPostAttachmentDetails: MessageDetailsComponent<MsgAnswerPollEncodeOb
   );
 };
 
-export default MsgAddPostAttachmentDetails;
+export default MsgAnswerPollDetails;

--- a/src/components/Messages/posts/MsgDeletePost/MsgDeletePostDetails/index.tsx
+++ b/src/components/Messages/posts/MsgDeletePost/MsgDeletePostDetails/index.tsx
@@ -9,9 +9,7 @@ import { MessageDetailsComponent } from 'components/Messages/BaseMessage';
  * Displays the full details of a MsgDeletePost
  * @constructor
  */
-const MsgEditSubspaceDetails: MessageDetailsComponent<MsgDeletePostEncodeObject> = ({
-  message,
-}) => {
+const MsgDeletePostDetails: MessageDetailsComponent<MsgDeletePostEncodeObject> = ({ message }) => {
   const { t } = useTranslation('messages.posts');
   const { t: tSubspaces } = useTranslation('messages.subspaces');
   const { t: tCommon } = useTranslation('messages.common');
@@ -39,4 +37,4 @@ const MsgEditSubspaceDetails: MessageDetailsComponent<MsgDeletePostEncodeObject>
   );
 };
 
-export default MsgEditSubspaceDetails;
+export default MsgDeletePostDetails;

--- a/src/components/Messages/posts/MsgRemovePostAttachment/MsgRemovePostAttachmentDetails/index.tsx
+++ b/src/components/Messages/posts/MsgRemovePostAttachment/MsgRemovePostAttachmentDetails/index.tsx
@@ -9,9 +9,9 @@ import { MessageDetailsComponent } from 'components/Messages/BaseMessage';
  * Displays the full details of a MsgRemovePostAttachment
  * @constructor
  */
-const MsgEditSubspaceDetails: MessageDetailsComponent<MsgRemovePostAttachmentEncodeObject> = ({
-  message,
-}) => {
+const MsgRemovePostAttachmentDetails: MessageDetailsComponent<
+  MsgRemovePostAttachmentEncodeObject
+> = ({ message }) => {
   const { t } = useTranslation('messages.posts');
   const { t: tSubspaces } = useTranslation('messages.subspaces');
 
@@ -46,4 +46,4 @@ const MsgEditSubspaceDetails: MessageDetailsComponent<MsgRemovePostAttachmentEnc
   );
 };
 
-export default MsgEditSubspaceDetails;
+export default MsgRemovePostAttachmentDetails;

--- a/src/components/Messages/reactions/MsgAddReaction/MsgAddReactionDetails/hooks.ts
+++ b/src/components/Messages/reactions/MsgAddReaction/MsgAddReactionDetails/hooks.ts
@@ -1,0 +1,53 @@
+import { useTranslation } from 'react-i18next';
+import React from 'react';
+import { Any } from 'cosmjs-types/google/protobuf/any';
+import { MessageDetailsField } from 'components/Messages/BaseMessage/BaseMessageDetails';
+import { decodeReactionValue } from 'lib/EncodeObjectUtils/reactions';
+import { FreeTextValueTypeUrl, RegisteredReactionValueTypeUrl } from '@desmoslabs/desmjs';
+
+const useGetReactionValueFields = () => {
+  const { t } = useTranslation('messages.reactions');
+
+  return React.useCallback(
+    (reaction: Any | undefined): MessageDetailsField[] => {
+      const decodeReactionResult = decodeReactionValue(reaction);
+
+      if (decodeReactionResult.isErr()) {
+        return [
+          {
+            label: t('unsupported reaction value'),
+            value: reaction?.typeUrl,
+          },
+        ];
+      }
+
+      const decodedValue = decodeReactionResult.value;
+      if (decodedValue === undefined) {
+        return [];
+      }
+
+      switch (decodedValue.typeUrl) {
+        case FreeTextValueTypeUrl:
+          return [
+            {
+              label: t('free text value reaction'),
+              value: decodedValue.value.text,
+            },
+          ];
+
+        case RegisteredReactionValueTypeUrl:
+          return [
+            {
+              label: t('registered reaction id'),
+              value: decodedValue.value.registeredReactionId.toString(),
+            },
+          ];
+        default:
+          return [];
+      }
+    },
+    [t],
+  );
+};
+
+export default useGetReactionValueFields;

--- a/src/components/Messages/reactions/MsgAddReaction/MsgAddReactionDetails/index.tsx
+++ b/src/components/Messages/reactions/MsgAddReaction/MsgAddReactionDetails/index.tsx
@@ -1,0 +1,46 @@
+import { MsgAddReactionEncodeObject } from '@desmoslabs/desmjs';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import BaseMessageDetails from 'components/Messages/BaseMessage/BaseMessageDetails';
+import { msgGeneralIcon } from 'assets/images';
+import { MessageDetailsComponent } from 'components/Messages/BaseMessage';
+import useGetReactionValueFields from 'components/Messages/reactions/MsgAddReaction/MsgAddReactionDetails/hooks';
+
+/**
+ * Displays the full details of a MsgAddReaction
+ * @constructor
+ */
+const MsgEditSubspaceDetails: MessageDetailsComponent<MsgAddReactionEncodeObject> = ({
+  message,
+}) => {
+  const { t } = useTranslation('messages.reactions');
+  const { t: tSubspaces } = useTranslation('messages.subspaces');
+  const { t: tPosts } = useTranslation('messages.posts');
+  const { t: tCommon } = useTranslation('messages.common');
+  const getReactionValueFields = useGetReactionValueFields();
+
+  const fields = React.useMemo(
+    () => [
+      {
+        label: tSubspaces('subspace id'),
+        value: message.value.subspaceId.toString(),
+      },
+      {
+        label: tPosts('post id'),
+        value: message.value.postId.toString(),
+      },
+      ...getReactionValueFields(message.value.value),
+      {
+        label: tCommon('user'),
+        value: message.value.user,
+      },
+    ],
+    [tSubspaces, message, tPosts, getReactionValueFields, tCommon],
+  );
+
+  return (
+    <BaseMessageDetails icon={msgGeneralIcon} iconSubtitle={t('add reaction')} fields={fields} />
+  );
+};
+
+export default MsgEditSubspaceDetails;

--- a/src/components/Messages/reactions/MsgAddReaction/MsgAddReactionDetails/index.tsx
+++ b/src/components/Messages/reactions/MsgAddReaction/MsgAddReactionDetails/index.tsx
@@ -10,7 +10,7 @@ import useGetReactionValueFields from 'components/Messages/reactions/MsgAddReact
  * Displays the full details of a MsgAddReaction
  * @constructor
  */
-const MsgEditSubspaceDetails: MessageDetailsComponent<MsgAddReactionEncodeObject> = ({
+const MsgAddReactionDetails: MessageDetailsComponent<MsgAddReactionEncodeObject> = ({
   message,
 }) => {
   const { t } = useTranslation('messages.reactions');
@@ -43,4 +43,4 @@ const MsgEditSubspaceDetails: MessageDetailsComponent<MsgAddReactionEncodeObject
   );
 };
 
-export default MsgEditSubspaceDetails;
+export default MsgAddReactionDetails;

--- a/src/components/Messages/reactions/MsgAddReaction/MsgAddReactionListItem/index.tsx
+++ b/src/components/Messages/reactions/MsgAddReaction/MsgAddReactionListItem/index.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { msgGeneralIcon } from 'assets/images';
+import { View } from 'react-native';
+import Typography from 'components/Typography';
+import BaseMessageListItem from 'components/Messages/BaseMessage/BaseMessageListItem';
+import { MessageListItemComponent } from 'components/Messages/BaseMessage';
+import { MsgAddReactionEncodeObject } from '@desmoslabs/desmjs';
+
+/**
+ * Displays the short details of a MsgAddReaction within a list.
+ * @constructor
+ */
+const MsgAddReactionListItem: MessageListItemComponent<MsgAddReactionEncodeObject> = ({
+  message,
+  date,
+}) => {
+  const { t } = useTranslation('messages.reactions');
+  const { t: tPosts } = useTranslation('messages.posts');
+  const { t: tSubspaces } = useTranslation('messages.subspaces');
+
+  return (
+    <BaseMessageListItem
+      icon={msgGeneralIcon}
+      date={date}
+      renderContent={() => (
+        <View>
+          <Typography.Body1>{t('add reaction')}</Typography.Body1>
+          <Typography.Caption>
+            {tSubspaces('subspace id')}: {message.value.subspaceId.toString()}
+          </Typography.Caption>
+          <Typography.Caption>
+            {tPosts('post id')}: {message.value.postId.toString()}
+          </Typography.Caption>
+        </View>
+      )}
+    />
+  );
+};
+
+export default MsgAddReactionListItem;

--- a/src/components/Messages/reactions/MsgAddReaction/index.tsx
+++ b/src/components/Messages/reactions/MsgAddReaction/index.tsx
@@ -1,0 +1,11 @@
+import { MsgAddReactionEncodeObject } from '@desmoslabs/desmjs';
+import { MessageComponents } from 'components/Messages/BaseMessage';
+import MsgAddReactionListItem from './MsgAddReactionListItem';
+import MsgAddReactionDetails from './MsgAddReactionDetails';
+
+const MsgAddReactionComponents: MessageComponents<MsgAddReactionEncodeObject> = {
+  listItem: MsgAddReactionListItem,
+  details: MsgAddReactionDetails,
+};
+
+export default MsgAddReactionComponents;

--- a/src/components/Messages/reactions/MsgAddRegisteredReaction/MsgAddRegisteredReactionDetails/index.tsx
+++ b/src/components/Messages/reactions/MsgAddRegisteredReaction/MsgAddRegisteredReactionDetails/index.tsx
@@ -1,0 +1,50 @@
+import { MsgAddRegisteredReactionEncodeObject } from '@desmoslabs/desmjs';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import BaseMessageDetails from 'components/Messages/BaseMessage/BaseMessageDetails';
+import { msgGeneralIcon } from 'assets/images';
+import { MessageDetailsComponent } from 'components/Messages/BaseMessage';
+
+/**
+ * Displays the full details of a MsgAddRegisteredReaction
+ * @constructor
+ */
+const MsgEditSubspaceDetails: MessageDetailsComponent<MsgAddRegisteredReactionEncodeObject> = ({
+  message,
+}) => {
+  const { t } = useTranslation('messages.reactions');
+  const { t: tSubspaces } = useTranslation('messages.subspaces');
+  const { t: tCommon } = useTranslation('messages.common');
+
+  const fields = React.useMemo(
+    () => [
+      {
+        label: tSubspaces('subspace id'),
+        value: message.value.subspaceId.toString(),
+      },
+      {
+        label: t('shorthand code'),
+        value: message.value.shorthandCode,
+      },
+      {
+        label: t('display value'),
+        value: message.value.displayValue,
+      },
+      {
+        label: tCommon('user'),
+        value: message.value.user,
+      },
+    ],
+    [tSubspaces, message, t, tCommon],
+  );
+
+  return (
+    <BaseMessageDetails
+      icon={msgGeneralIcon}
+      iconSubtitle={t('add registered reaction')}
+      fields={fields}
+    />
+  );
+};
+
+export default MsgEditSubspaceDetails;

--- a/src/components/Messages/reactions/MsgAddRegisteredReaction/MsgAddRegisteredReactionDetails/index.tsx
+++ b/src/components/Messages/reactions/MsgAddRegisteredReaction/MsgAddRegisteredReactionDetails/index.tsx
@@ -9,9 +9,9 @@ import { MessageDetailsComponent } from 'components/Messages/BaseMessage';
  * Displays the full details of a MsgAddRegisteredReaction
  * @constructor
  */
-const MsgEditSubspaceDetails: MessageDetailsComponent<MsgAddRegisteredReactionEncodeObject> = ({
-  message,
-}) => {
+const MsgAddRegisteredReactionDetails: MessageDetailsComponent<
+  MsgAddRegisteredReactionEncodeObject
+> = ({ message }) => {
   const { t } = useTranslation('messages.reactions');
   const { t: tSubspaces } = useTranslation('messages.subspaces');
   const { t: tCommon } = useTranslation('messages.common');
@@ -47,4 +47,4 @@ const MsgEditSubspaceDetails: MessageDetailsComponent<MsgAddRegisteredReactionEn
   );
 };
 
-export default MsgEditSubspaceDetails;
+export default MsgAddRegisteredReactionDetails;

--- a/src/components/Messages/reactions/MsgAddRegisteredReaction/MsgAddRegisteredReactionListItem/index.tsx
+++ b/src/components/Messages/reactions/MsgAddRegisteredReaction/MsgAddRegisteredReactionListItem/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { msgGeneralIcon } from 'assets/images';
+import { View } from 'react-native';
+import Typography from 'components/Typography';
+import BaseMessageListItem from 'components/Messages/BaseMessage/BaseMessageListItem';
+import { MessageListItemComponent } from 'components/Messages/BaseMessage';
+import { MsgAddRegisteredReactionEncodeObject } from '@desmoslabs/desmjs';
+
+/**
+ * Displays the short details of a MsgAddRegisteredReaction within a list.
+ * @constructor
+ */
+const MsgAddRegisteredReactionListItem: MessageListItemComponent<
+  MsgAddRegisteredReactionEncodeObject
+> = ({ message, date }) => {
+  const { t } = useTranslation('messages.reactions');
+  const { t: tSubspaces } = useTranslation('messages.subspaces');
+
+  return (
+    <BaseMessageListItem
+      icon={msgGeneralIcon}
+      date={date}
+      renderContent={() => (
+        <View>
+          <Typography.Body1>{t('add registered reaction')}</Typography.Body1>
+          <Typography.Caption>
+            {tSubspaces('subspace id')}: {message.value.subspaceId.toString()}
+          </Typography.Caption>
+          <Typography.Caption>
+            {t('display value')}: {message.value.displayValue}
+          </Typography.Caption>
+        </View>
+      )}
+    />
+  );
+};
+
+export default MsgAddRegisteredReactionListItem;

--- a/src/components/Messages/reactions/MsgAddRegisteredReaction/index.tsx
+++ b/src/components/Messages/reactions/MsgAddRegisteredReaction/index.tsx
@@ -1,0 +1,12 @@
+import { MsgAddRegisteredReactionEncodeObject } from '@desmoslabs/desmjs';
+import { MessageComponents } from 'components/Messages/BaseMessage';
+import MsgAddRegisteredReactionListItem from './MsgAddRegisteredReactionListItem';
+import MsgAddRegisteredReactionDetails from './MsgAddRegisteredReactionDetails';
+
+const MsgAddRegisteredReactionComponents: MessageComponents<MsgAddRegisteredReactionEncodeObject> =
+  {
+    listItem: MsgAddRegisteredReactionListItem,
+    details: MsgAddRegisteredReactionDetails,
+  };
+
+export default MsgAddRegisteredReactionComponents;

--- a/src/components/Messages/reactions/MsgEditRegisteredReaction/MsgEditRegisteredReactionDetails/index.tsx
+++ b/src/components/Messages/reactions/MsgEditRegisteredReaction/MsgEditRegisteredReactionDetails/index.tsx
@@ -9,9 +9,9 @@ import { MessageDetailsComponent } from 'components/Messages/BaseMessage';
  * Displays the full details of a MsgEditRegisteredReaction
  * @constructor
  */
-const MsgEditSubspaceDetails: MessageDetailsComponent<MsgEditRegisteredReactionEncodeObject> = ({
-  message,
-}) => {
+const MsgEditRegisteredReactionDetails: MessageDetailsComponent<
+  MsgEditRegisteredReactionEncodeObject
+> = ({ message }) => {
   const { t } = useTranslation('messages.reactions');
   const { t: tSubspaces } = useTranslation('messages.subspaces');
   const { t: tCommon } = useTranslation('messages.common');
@@ -51,4 +51,4 @@ const MsgEditSubspaceDetails: MessageDetailsComponent<MsgEditRegisteredReactionE
   );
 };
 
-export default MsgEditSubspaceDetails;
+export default MsgEditRegisteredReactionDetails;

--- a/src/components/Messages/reactions/MsgEditRegisteredReaction/MsgEditRegisteredReactionDetails/index.tsx
+++ b/src/components/Messages/reactions/MsgEditRegisteredReaction/MsgEditRegisteredReactionDetails/index.tsx
@@ -1,0 +1,54 @@
+import { MsgEditRegisteredReactionEncodeObject } from '@desmoslabs/desmjs';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import BaseMessageDetails from 'components/Messages/BaseMessage/BaseMessageDetails';
+import { msgGeneralIcon } from 'assets/images';
+import { MessageDetailsComponent } from 'components/Messages/BaseMessage';
+
+/**
+ * Displays the full details of a MsgEditRegisteredReaction
+ * @constructor
+ */
+const MsgEditSubspaceDetails: MessageDetailsComponent<MsgEditRegisteredReactionEncodeObject> = ({
+  message,
+}) => {
+  const { t } = useTranslation('messages.reactions');
+  const { t: tSubspaces } = useTranslation('messages.subspaces');
+  const { t: tCommon } = useTranslation('messages.common');
+
+  const fields = React.useMemo(
+    () => [
+      {
+        label: tSubspaces('subspace id'),
+        value: message.value.subspaceId.toString(),
+      },
+      {
+        label: t('registered reaction id'),
+        value: message.value.registeredReactionId.toString(),
+      },
+      {
+        label: t('shorthand code'),
+        value: message.value.shorthandCode,
+      },
+      {
+        label: t('display value'),
+        value: message.value.displayValue,
+      },
+      {
+        label: tCommon('user'),
+        value: message.value.user,
+      },
+    ],
+    [tSubspaces, message, t, tCommon],
+  );
+
+  return (
+    <BaseMessageDetails
+      icon={msgGeneralIcon}
+      iconSubtitle={t('edit registered reaction')}
+      fields={fields}
+    />
+  );
+};
+
+export default MsgEditSubspaceDetails;

--- a/src/components/Messages/reactions/MsgEditRegisteredReaction/MsgEditRegisteredReactionListItem/index.tsx
+++ b/src/components/Messages/reactions/MsgEditRegisteredReaction/MsgEditRegisteredReactionListItem/index.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { msgGeneralIcon } from 'assets/images';
+import { View } from 'react-native';
+import Typography from 'components/Typography';
+import BaseMessageListItem from 'components/Messages/BaseMessage/BaseMessageListItem';
+import { MessageListItemComponent } from 'components/Messages/BaseMessage';
+import { MsgEditRegisteredReactionEncodeObject } from '@desmoslabs/desmjs';
+
+/**
+ * Displays the short details of a MsgEditRegisteredReaction within a list.
+ * @constructor
+ */
+const MsgEditRegisteredReactionListItem: MessageListItemComponent<
+  MsgEditRegisteredReactionEncodeObject
+> = ({ message, date }) => {
+  const { t } = useTranslation('messages.reactions');
+  const { t: tSubspaces } = useTranslation('messages.subspaces');
+
+  return (
+    <BaseMessageListItem
+      icon={msgGeneralIcon}
+      date={date}
+      renderContent={() => (
+        <View>
+          <Typography.Body1>
+            {t('edit registered reaction')} {message.value.registeredReactionId.toString()}
+          </Typography.Body1>
+          <Typography.Caption>
+            {tSubspaces('subspace id')}: {message.value.subspaceId.toString()}
+          </Typography.Caption>
+        </View>
+      )}
+    />
+  );
+};
+
+export default MsgEditRegisteredReactionListItem;

--- a/src/components/Messages/reactions/MsgEditRegisteredReaction/index.tsx
+++ b/src/components/Messages/reactions/MsgEditRegisteredReaction/index.tsx
@@ -1,0 +1,12 @@
+import { MsgEditRegisteredReactionEncodeObject } from '@desmoslabs/desmjs';
+import { MessageComponents } from 'components/Messages/BaseMessage';
+import MsgEditRegisteredReactionListItem from './MsgEditRegisteredReactionListItem';
+import MsgEditRegisteredReactionDetails from './MsgEditRegisteredReactionDetails';
+
+const MsgEditRegisteredReactionComponents: MessageComponents<MsgEditRegisteredReactionEncodeObject> =
+  {
+    listItem: MsgEditRegisteredReactionListItem,
+    details: MsgEditRegisteredReactionDetails,
+  };
+
+export default MsgEditRegisteredReactionComponents;

--- a/src/components/Messages/reactions/MsgRemoveReaction/MsgRemoveReactionDetails/index.tsx
+++ b/src/components/Messages/reactions/MsgRemoveReaction/MsgRemoveReactionDetails/index.tsx
@@ -9,7 +9,7 @@ import { MessageDetailsComponent } from 'components/Messages/BaseMessage';
  * Displays the full details of a MsgRemoveReaction
  * @constructor
  */
-const MsgEditSubspaceDetails: MessageDetailsComponent<MsgRemoveReactionEncodeObject> = ({
+const MsgRemoveReactionDetails: MessageDetailsComponent<MsgRemoveReactionEncodeObject> = ({
   message,
 }) => {
   const { t } = useTranslation('messages.reactions');
@@ -44,4 +44,4 @@ const MsgEditSubspaceDetails: MessageDetailsComponent<MsgRemoveReactionEncodeObj
   );
 };
 
-export default MsgEditSubspaceDetails;
+export default MsgRemoveReactionDetails;

--- a/src/components/Messages/reactions/MsgRemoveReaction/MsgRemoveReactionDetails/index.tsx
+++ b/src/components/Messages/reactions/MsgRemoveReaction/MsgRemoveReactionDetails/index.tsx
@@ -1,0 +1,47 @@
+import { MsgRemoveReactionEncodeObject } from '@desmoslabs/desmjs';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import BaseMessageDetails from 'components/Messages/BaseMessage/BaseMessageDetails';
+import { msgGeneralIcon } from 'assets/images';
+import { MessageDetailsComponent } from 'components/Messages/BaseMessage';
+
+/**
+ * Displays the full details of a MsgRemoveReaction
+ * @constructor
+ */
+const MsgEditSubspaceDetails: MessageDetailsComponent<MsgRemoveReactionEncodeObject> = ({
+  message,
+}) => {
+  const { t } = useTranslation('messages.reactions');
+  const { t: tSubspaces } = useTranslation('messages.subspaces');
+  const { t: tPosts } = useTranslation('messages.posts');
+  const { t: tCommon } = useTranslation('messages.common');
+
+  const fields = React.useMemo(
+    () => [
+      {
+        label: tSubspaces('subspace id'),
+        value: message.value.subspaceId.toString(),
+      },
+      {
+        label: tPosts('post id'),
+        value: message.value.postId.toString(),
+      },
+      {
+        label: t('reaction id'),
+        value: message.value.reactionId.toString(),
+      },
+      {
+        label: tCommon('user'),
+        value: message.value.user,
+      },
+    ],
+    [tSubspaces, message, tPosts, t, tCommon],
+  );
+
+  return (
+    <BaseMessageDetails icon={msgGeneralIcon} iconSubtitle={t('remove reaction')} fields={fields} />
+  );
+};
+
+export default MsgEditSubspaceDetails;

--- a/src/components/Messages/reactions/MsgRemoveReaction/MsgRemoveReactionListItem/index.tsx
+++ b/src/components/Messages/reactions/MsgRemoveReaction/MsgRemoveReactionListItem/index.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { msgGeneralIcon } from 'assets/images';
+import { View } from 'react-native';
+import Typography from 'components/Typography';
+import BaseMessageListItem from 'components/Messages/BaseMessage/BaseMessageListItem';
+import { MessageListItemComponent } from 'components/Messages/BaseMessage';
+import { MsgRemoveReactionEncodeObject } from '@desmoslabs/desmjs';
+
+/**
+ * Displays the short details of a MsgRemoveReaction within a list.
+ * @constructor
+ */
+const MsgRemoveReactionListItem: MessageListItemComponent<MsgRemoveReactionEncodeObject> = ({
+  message,
+  date,
+}) => {
+  const { t } = useTranslation('messages.reactions');
+  const { t: tPosts } = useTranslation('messages.posts');
+  const { t: tSubspaces } = useTranslation('messages.subspaces');
+
+  return (
+    <BaseMessageListItem
+      icon={msgGeneralIcon}
+      date={date}
+      renderContent={() => (
+        <View>
+          <Typography.Body1>
+            {t('remove reaction')} {message.value.reactionId.toString()}
+          </Typography.Body1>
+          <Typography.Caption>
+            {tSubspaces('subspace id')}: {message.value.subspaceId.toString()}
+          </Typography.Caption>
+          <Typography.Caption>
+            {tPosts('post id')}: {message.value.postId.toString()}
+          </Typography.Caption>
+        </View>
+      )}
+    />
+  );
+};
+
+export default MsgRemoveReactionListItem;

--- a/src/components/Messages/reactions/MsgRemoveReaction/index.tsx
+++ b/src/components/Messages/reactions/MsgRemoveReaction/index.tsx
@@ -1,0 +1,11 @@
+import { MsgRemoveReactionEncodeObject } from '@desmoslabs/desmjs';
+import { MessageComponents } from 'components/Messages/BaseMessage';
+import MsgRemoveReactionListItem from './MsgRemoveReactionListItem';
+import MsgRemoveReactionDetails from './MsgRemoveReactionDetails';
+
+const MsgRemoveReactionComponents: MessageComponents<MsgRemoveReactionEncodeObject> = {
+  listItem: MsgRemoveReactionListItem,
+  details: MsgRemoveReactionDetails,
+};
+
+export default MsgRemoveReactionComponents;

--- a/src/components/Messages/reactions/MsgRemoveRegisteredReaction/MsgRemoveRegisteredReactionDetails/index.tsx
+++ b/src/components/Messages/reactions/MsgRemoveRegisteredReaction/MsgRemoveRegisteredReactionDetails/index.tsx
@@ -1,0 +1,46 @@
+import { MsgRemoveRegisteredReactionEncodeObject } from '@desmoslabs/desmjs';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import BaseMessageDetails from 'components/Messages/BaseMessage/BaseMessageDetails';
+import { msgGeneralIcon } from 'assets/images';
+import { MessageDetailsComponent } from 'components/Messages/BaseMessage';
+
+/**
+ * Displays the full details of a MsgRemoveRegisteredReaction
+ * @constructor
+ */
+const MsgEditSubspaceDetails: MessageDetailsComponent<MsgRemoveRegisteredReactionEncodeObject> = ({
+  message,
+}) => {
+  const { t } = useTranslation('messages.reactions');
+  const { t: tSubspaces } = useTranslation('messages.subspaces');
+  const { t: tCommon } = useTranslation('messages.common');
+
+  const fields = React.useMemo(
+    () => [
+      {
+        label: tSubspaces('subspace id'),
+        value: message.value.subspaceId.toString(),
+      },
+      {
+        label: t('registered reaction id'),
+        value: message.value.registeredReactionId.toString(),
+      },
+      {
+        label: tCommon('user'),
+        value: message.value.user,
+      },
+    ],
+    [tSubspaces, message, t, tCommon],
+  );
+
+  return (
+    <BaseMessageDetails
+      icon={msgGeneralIcon}
+      iconSubtitle={t('remove registered reaction')}
+      fields={fields}
+    />
+  );
+};
+
+export default MsgEditSubspaceDetails;

--- a/src/components/Messages/reactions/MsgRemoveRegisteredReaction/MsgRemoveRegisteredReactionDetails/index.tsx
+++ b/src/components/Messages/reactions/MsgRemoveRegisteredReaction/MsgRemoveRegisteredReactionDetails/index.tsx
@@ -9,9 +9,9 @@ import { MessageDetailsComponent } from 'components/Messages/BaseMessage';
  * Displays the full details of a MsgRemoveRegisteredReaction
  * @constructor
  */
-const MsgEditSubspaceDetails: MessageDetailsComponent<MsgRemoveRegisteredReactionEncodeObject> = ({
-  message,
-}) => {
+const MsgRemoveRegisteredReactionDetails: MessageDetailsComponent<
+  MsgRemoveRegisteredReactionEncodeObject
+> = ({ message }) => {
   const { t } = useTranslation('messages.reactions');
   const { t: tSubspaces } = useTranslation('messages.subspaces');
   const { t: tCommon } = useTranslation('messages.common');
@@ -43,4 +43,4 @@ const MsgEditSubspaceDetails: MessageDetailsComponent<MsgRemoveRegisteredReactio
   );
 };
 
-export default MsgEditSubspaceDetails;
+export default MsgRemoveRegisteredReactionDetails;

--- a/src/components/Messages/reactions/MsgRemoveRegisteredReaction/MsgRemoveRegisteredReactionListItem/index.tsx
+++ b/src/components/Messages/reactions/MsgRemoveRegisteredReaction/MsgRemoveRegisteredReactionListItem/index.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { msgGeneralIcon } from 'assets/images';
+import { View } from 'react-native';
+import Typography from 'components/Typography';
+import BaseMessageListItem from 'components/Messages/BaseMessage/BaseMessageListItem';
+import { MessageListItemComponent } from 'components/Messages/BaseMessage';
+import { MsgRemoveRegisteredReactionEncodeObject } from '@desmoslabs/desmjs';
+
+/**
+ * Displays the short details of a MsgRemoveRegisteredReaction within a list.
+ * @constructor
+ */
+const MsgRemoveRegisteredReactionListItem: MessageListItemComponent<
+  MsgRemoveRegisteredReactionEncodeObject
+> = ({ message, date }) => {
+  const { t } = useTranslation('messages.reactions');
+  const { t: tSubspaces } = useTranslation('messages.subspaces');
+
+  return (
+    <BaseMessageListItem
+      icon={msgGeneralIcon}
+      date={date}
+      renderContent={() => (
+        <View>
+          <Typography.Body1>
+            {t('remove registered reaction')} {message.value.registeredReactionId.toString()}
+          </Typography.Body1>
+          <Typography.Caption>
+            {tSubspaces('subspace id')}: {message.value.subspaceId.toString()}
+          </Typography.Caption>
+        </View>
+      )}
+    />
+  );
+};
+
+export default MsgRemoveRegisteredReactionListItem;

--- a/src/components/Messages/reactions/MsgRemoveRegisteredReaction/index.tsx
+++ b/src/components/Messages/reactions/MsgRemoveRegisteredReaction/index.tsx
@@ -1,0 +1,12 @@
+import { MsgRemoveRegisteredReactionEncodeObject } from '@desmoslabs/desmjs';
+import { MessageComponents } from 'components/Messages/BaseMessage';
+import MsgRemoveRegisteredReactionListItem from './MsgRemoveRegisteredReactionListItem';
+import MsgRemoveRegisteredReactionDetails from './MsgRemoveRegisteredReactionDetails';
+
+const MsgRemoveRegisteredReactionComponents: MessageComponents<MsgRemoveRegisteredReactionEncodeObject> =
+  {
+    listItem: MsgRemoveRegisteredReactionListItem,
+    details: MsgRemoveRegisteredReactionDetails,
+  };
+
+export default MsgRemoveRegisteredReactionComponents;

--- a/src/components/Messages/reactions/MsgSetReactionsParams/MsgSetReactionsParamsDetails/index.tsx
+++ b/src/components/Messages/reactions/MsgSetReactionsParams/MsgSetReactionsParamsDetails/index.tsx
@@ -1,0 +1,64 @@
+import { MsgSetReactionsParamsEncodeObject } from '@desmoslabs/desmjs';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import BaseMessageDetails, {
+  MessageDetailsField,
+} from 'components/Messages/BaseMessage/BaseMessageDetails';
+import { msgGeneralIcon } from 'assets/images';
+import { MessageDetailsComponent } from 'components/Messages/BaseMessage';
+
+/**
+ * Displays the full details of a MsgSetReactionsParams
+ * @constructor
+ */
+const MsgSetReactionsDetails: MessageDetailsComponent<MsgSetReactionsParamsEncodeObject> = ({
+  message,
+}) => {
+  const { t } = useTranslation('messages.reactions');
+  const { t: tSubspaces } = useTranslation('messages.subspaces');
+  const { t: tCommon } = useTranslation('messages.common');
+
+  const fields = React.useMemo(
+    (): MessageDetailsField[] => [
+      {
+        label: tSubspaces('subspace id'),
+        value: message.value.subspaceId.toString(),
+      },
+      {
+        label: t('registered reactions enabled'),
+        value: message.value.registeredReaction?.enabled?.toString(),
+        hide: message.value.registeredReaction?.enabled === undefined,
+      },
+      {
+        label: t('free text reactions enabled'),
+        value: message.value.freeText?.enabled?.toString(),
+        hide: message.value.freeText?.enabled === undefined,
+      },
+      {
+        label: t('free text reactions max length'),
+        value: message.value.freeText?.maxLength?.toString(),
+        hide: message.value.freeText?.maxLength === undefined,
+      },
+      {
+        label: t('free text reactions regex'),
+        value: message.value.freeText?.regEx,
+        hide: message.value.freeText?.regEx === undefined,
+      },
+      {
+        label: tCommon('user'),
+        value: message.value.user,
+      },
+    ],
+    [t, tSubspaces, message, tCommon],
+  );
+
+  return (
+    <BaseMessageDetails
+      icon={msgGeneralIcon}
+      iconSubtitle={t('set reactions params')}
+      fields={fields}
+    />
+  );
+};
+
+export default MsgSetReactionsDetails;

--- a/src/components/Messages/reactions/MsgSetReactionsParams/MsgSetReactionsParamsListItem/index.tsx
+++ b/src/components/Messages/reactions/MsgSetReactionsParams/MsgSetReactionsParamsListItem/index.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { msgGeneralIcon } from 'assets/images';
+import { View } from 'react-native';
+import Typography from 'components/Typography';
+import BaseMessageListItem from 'components/Messages/BaseMessage/BaseMessageListItem';
+import { MessageListItemComponent } from 'components/Messages/BaseMessage';
+import { MsgSetReactionsParamsEncodeObject } from '@desmoslabs/desmjs';
+
+/**
+ * Displays the short details of a MsgSetReactionsParams within a list.
+ * @constructor
+ */
+const MsgSetReactionsParamsListItem: MessageListItemComponent<
+  MsgSetReactionsParamsEncodeObject
+> = ({ message, date }) => {
+  const { t } = useTranslation('messages.reactions');
+  const { t: tSubspaces } = useTranslation('messages.subspaces');
+
+  return (
+    <BaseMessageListItem
+      icon={msgGeneralIcon}
+      date={date}
+      renderContent={() => (
+        <View>
+          <Typography.Body1>{t('set reactions params')}</Typography.Body1>
+          <Typography.Caption>
+            {tSubspaces('subspace id')}: {message.value.subspaceId.toString()}
+          </Typography.Caption>
+        </View>
+      )}
+    />
+  );
+};
+
+export default MsgSetReactionsParamsListItem;

--- a/src/components/Messages/reactions/MsgSetReactionsParams/index.tsx
+++ b/src/components/Messages/reactions/MsgSetReactionsParams/index.tsx
@@ -1,0 +1,11 @@
+import { MsgSetReactionsParamsEncodeObject } from '@desmoslabs/desmjs';
+import { MessageComponents } from 'components/Messages/BaseMessage';
+import MsgSetReactionsParamsListItem from './MsgSetReactionsParamsListItem';
+import MsgSetReactionsParamsDetails from './MsgSetReactionsParamsDetails';
+
+const MsgSetReactionsParamsComponents: MessageComponents<MsgSetReactionsParamsEncodeObject> = {
+  listItem: MsgSetReactionsParamsListItem,
+  details: MsgSetReactionsParamsDetails,
+};
+
+export default MsgSetReactionsParamsComponents;

--- a/src/components/Messages/subspaces/MsgDeleteSubspace/MsgDeleteSubspaceDetails/index.tsx
+++ b/src/components/Messages/subspaces/MsgDeleteSubspace/MsgDeleteSubspaceDetails/index.tsx
@@ -9,7 +9,7 @@ import { MessageDetailsComponent } from 'components/Messages/BaseMessage';
  * Displays the full details of a MsgDeleteSubspace
  * @constructor
  */
-const MsgEditSubspaceDetails: MessageDetailsComponent<MsgDeleteSubspaceEncodeObject> = ({
+const MsgDeleteSubspaceDetails: MessageDetailsComponent<MsgDeleteSubspaceEncodeObject> = ({
   message,
 }) => {
   const { t } = useTranslation('messages.subspaces');
@@ -33,4 +33,4 @@ const MsgEditSubspaceDetails: MessageDetailsComponent<MsgDeleteSubspaceEncodeObj
   );
 };
 
-export default MsgEditSubspaceDetails;
+export default MsgDeleteSubspaceDetails;

--- a/src/lib/EncodeObjectUtils/reactions.ts
+++ b/src/lib/EncodeObjectUtils/reactions.ts
@@ -1,0 +1,46 @@
+import { FreeTextValueTypeUrl, RegisteredReactionValueTypeUrl } from '@desmoslabs/desmjs';
+import {
+  FreeTextValue,
+  RegisteredReactionValue,
+} from '@desmoslabs/desmjs-types/desmos/reactions/v1/models';
+import { Any } from 'cosmjs-types/google/protobuf/any';
+import { err, ok, Result } from 'neverthrow';
+
+export interface FreeTextValueReactionEncodeObject {
+  readonly typeUrl: typeof FreeTextValueTypeUrl;
+  readonly value: FreeTextValue;
+}
+
+export interface RegisteredReactionValueEncodeObject {
+  readonly typeUrl: typeof RegisteredReactionValueTypeUrl;
+  readonly value: RegisteredReactionValue;
+}
+
+export type ReactionValueEncodeObject =
+  | FreeTextValueReactionEncodeObject
+  | RegisteredReactionValueEncodeObject;
+
+export function decodeReactionValue(
+  value: Any | undefined,
+): Result<ReactionValueEncodeObject | undefined, Error> {
+  if (value === undefined) {
+    return ok(undefined);
+  }
+
+  switch (value.typeUrl) {
+    case FreeTextValueTypeUrl:
+      return ok({
+        typeUrl: FreeTextValueTypeUrl,
+        value: FreeTextValue.decode(value.value),
+      });
+
+    case RegisteredReactionValueTypeUrl:
+      return ok({
+        typeUrl: RegisteredReactionValueTypeUrl,
+        value: RegisteredReactionValue.decode(value.value),
+      });
+
+    default:
+      return err(new Error(`Unknown reaction value type: ${value.typeUrl}`));
+  }
+}

--- a/src/lib/TransactionUtils/decoders.ts
+++ b/src/lib/TransactionUtils/decoders.ts
@@ -41,6 +41,8 @@ import {
   MsgDeleteUserGroupTypeUrl,
   MsgEditPostEncodeObject,
   MsgEditPostTypeUrl,
+  MsgEditRegisteredReactionEncodeObject,
+  MsgEditRegisteredReactionTypeUrl,
   MsgEditSectionEncodeObject,
   MsgEditSectionTypeUrl,
   MsgEditSubspaceEncodeObject,
@@ -136,6 +138,7 @@ import {
 import {
   MsgAddReaction,
   MsgAddRegisteredReaction,
+  MsgEditRegisteredReaction,
   MsgRemoveReaction,
 } from '@desmoslabs/desmjs-types/desmos/reactions/v1/msgs';
 import {
@@ -910,6 +913,18 @@ const decodeReactionsMessage = (type: string, value: any): EncodeObject | undefi
           user: value.user,
         }),
       } as MsgAddRegisteredReactionEncodeObject;
+
+    case MsgEditRegisteredReactionTypeUrl:
+      return {
+        typeUrl: MsgEditRegisteredReactionTypeUrl,
+        value: MsgEditRegisteredReaction.fromPartial({
+          subspaceId: value.subspace_id,
+          registeredReactionId: value.registered_reaction_id,
+          shorthandCode: value.shorthand_code,
+          displayValue: value.display_value,
+          user: value.user,
+        }),
+      } as MsgEditRegisteredReactionEncodeObject;
 
     default:
       return undefined;

--- a/src/lib/TransactionUtils/decoders.ts
+++ b/src/lib/TransactionUtils/decoders.ts
@@ -57,6 +57,8 @@ import {
   MsgMoveUserGroupTypeUrl,
   MsgRemovePostAttachmentEncodeObject,
   MsgRemovePostAttachmentTypeUrl,
+  MsgRemoveReactionEncodeObject,
+  MsgRemoveReactionTypeUrl,
   MsgRemoveUserFromUserGroupEncodeObject,
   MsgRemoveUserFromUserGroupTypeUrl,
   MsgRevokeEncodeObject,
@@ -129,7 +131,10 @@ import {
   replySettingFromJSON,
   Url,
 } from '@desmoslabs/desmjs-types/desmos/posts/v2/models';
-import { MsgAddReaction } from '@desmoslabs/desmjs-types/desmos/reactions/v1/msgs';
+import {
+  MsgAddReaction,
+  MsgRemoveReaction,
+} from '@desmoslabs/desmjs-types/desmos/reactions/v1/msgs';
 import {
   FreeTextValue,
   RegisteredReactionValue,
@@ -880,6 +885,17 @@ const decodeReactionsMessage = (type: string, value: any): EncodeObject | undefi
           user: value.user,
         }),
       } as MsgAddReactionEncodeObject;
+
+    case MsgRemoveReactionTypeUrl:
+      return {
+        typeUrl: MsgRemoveReactionTypeUrl,
+        value: MsgRemoveReaction.fromPartial({
+          subspaceId: value.subspace_id,
+          postId: value.post_id,
+          reactionId: value.reaction_id,
+          user: value.user,
+        }),
+      } as MsgRemoveReactionEncodeObject;
 
     default:
       return undefined;

--- a/src/lib/TransactionUtils/decoders.ts
+++ b/src/lib/TransactionUtils/decoders.ts
@@ -19,6 +19,8 @@ import {
   MsgAddPostAttachmentTypeUrl,
   MsgAddReactionEncodeObject,
   MsgAddReactionTypeUrl,
+  MsgAddRegisteredReactionEncodeObject,
+  MsgAddRegisteredReactionTypeUrl,
   MsgAddUserToUserGroupEncodeObject,
   MsgAddUserToUserGroupTypeUrl,
   MsgAnswerPollEncodeObject,
@@ -133,6 +135,7 @@ import {
 } from '@desmoslabs/desmjs-types/desmos/posts/v2/models';
 import {
   MsgAddReaction,
+  MsgAddRegisteredReaction,
   MsgRemoveReaction,
 } from '@desmoslabs/desmjs-types/desmos/reactions/v1/msgs';
 import {
@@ -896,6 +899,17 @@ const decodeReactionsMessage = (type: string, value: any): EncodeObject | undefi
           user: value.user,
         }),
       } as MsgRemoveReactionEncodeObject;
+
+    case MsgAddRegisteredReactionTypeUrl:
+      return {
+        typeUrl: MsgAddRegisteredReactionTypeUrl,
+        value: MsgAddRegisteredReaction.fromPartial({
+          subspaceId: value.subspace_id,
+          displayValue: value.display_value,
+          shorthandCode: value.shorthand_code,
+          user: value.user,
+        }),
+      } as MsgAddRegisteredReactionEncodeObject;
 
     default:
       return undefined;

--- a/src/lib/TransactionUtils/decoders.ts
+++ b/src/lib/TransactionUtils/decoders.ts
@@ -63,6 +63,8 @@ import {
   MsgRemovePostAttachmentTypeUrl,
   MsgRemoveReactionEncodeObject,
   MsgRemoveReactionTypeUrl,
+  MsgRemoveRegisteredReactionEncodeObject,
+  MsgRemoveRegisteredReactionTypeUrl,
   MsgRemoveUserFromUserGroupEncodeObject,
   MsgRemoveUserFromUserGroupTypeUrl,
   MsgRevokeEncodeObject,
@@ -140,6 +142,7 @@ import {
   MsgAddRegisteredReaction,
   MsgEditRegisteredReaction,
   MsgRemoveReaction,
+  MsgRemoveRegisteredReaction,
 } from '@desmoslabs/desmjs-types/desmos/reactions/v1/msgs';
 import {
   FreeTextValue,
@@ -925,6 +928,16 @@ const decodeReactionsMessage = (type: string, value: any): EncodeObject | undefi
           user: value.user,
         }),
       } as MsgEditRegisteredReactionEncodeObject;
+
+    case MsgRemoveRegisteredReactionTypeUrl:
+      return {
+        typeUrl: MsgRemoveRegisteredReactionTypeUrl,
+        value: MsgRemoveRegisteredReaction.fromPartial({
+          subspaceId: value.subspace_id,
+          registeredReactionId: value.registered_reaction_id,
+          user: value.user,
+        }),
+      } as MsgRemoveRegisteredReactionEncodeObject;
 
     default:
       return undefined;

--- a/src/lib/TransactionUtils/decoders.ts
+++ b/src/lib/TransactionUtils/decoders.ts
@@ -71,6 +71,8 @@ import {
   MsgRevokeTypeUrl,
   MsgSaveProfileEncodeObject,
   MsgSaveProfileTypeUrl,
+  MsgSetReactionsParamsEncodeObject,
+  MsgSetReactionsParamsTypeUrl,
   MsgSetUserGroupPermissionsEncodeObject,
   MsgSetUserGroupPermissionsTypeUrl,
   MsgSetUserPermissionsEncodeObject,
@@ -143,6 +145,7 @@ import {
   MsgEditRegisteredReaction,
   MsgRemoveReaction,
   MsgRemoveRegisteredReaction,
+  MsgSetReactionsParams,
 } from '@desmoslabs/desmjs-types/desmos/reactions/v1/msgs';
 import {
   FreeTextValue,
@@ -938,6 +941,23 @@ const decodeReactionsMessage = (type: string, value: any): EncodeObject | undefi
           user: value.user,
         }),
       } as MsgRemoveRegisteredReactionEncodeObject;
+
+    case MsgSetReactionsParamsTypeUrl:
+      return {
+        typeUrl: MsgSetReactionsParamsTypeUrl,
+        value: MsgSetReactionsParams.fromPartial({
+          subspaceId: value.subspace_id,
+          registeredReaction: value.registered_reaction,
+          freeText: value.free_text
+            ? {
+                enabled: value.free_text.enabled,
+                regEx: value.free_text.reg_ex,
+                maxLength: value.free_text.max_length,
+              }
+            : undefined,
+          user: value.user,
+        }),
+      } as MsgSetReactionsParamsEncodeObject;
 
     default:
       return undefined;


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR adds the support to the following `x/reactions` messages:
- MsgAddReaction
- MsgRemoveRegisteredReaction
- MsgAddRegisteredReaction
- MsgSetReactionsParams
- MsgRemoveReaction
- MsgEditRegisteredReaction

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
