### PR TITLE
build(android): removed v8 engine

### DIFF
--- a/android/app/src/main/java/network/desmos/dpm/MainApplication.java
+++ b/android/app/src/main/java/network/desmos/dpm/MainApplication.java
@@ -15,9 +15,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import com.facebook.react.bridge.JSIModulePackage;
 import com.swmansion.reanimated.ReanimatedJSIModulePackage;
-import com.facebook.react.bridge.JavaScriptExecutorFactory;
-import com.facebook.react.modules.systeminfo.AndroidInfoHelpers;
-import io.csie.kudo.reactnative.v8.executor.V8ExecutorFactory;
 
 
 public class MainApplication extends Application implements ReactApplication {
@@ -45,15 +42,6 @@ public class MainApplication extends Application implements ReactApplication {
         @Override
         protected JSIModulePackage getJSIModulePackage() {
             return new ReanimatedJSIModulePackage();
-        }
-
-        @Override
-        protected JavaScriptExecutorFactory getJavaScriptExecutorFactory() {
-            return new V8ExecutorFactory(
-                getApplicationContext(),
-                getPackageName(),
-                AndroidInfoHelpers.getFriendlyDeviceName(),
-                getUseDeveloperSupport());
         }
       };
 

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "react-native-safe-area-context": "^3.2.0",
     "react-native-screens": "^3.18.2",
     "react-native-svg": "^13.7.0",
-    "react-native-v8": "^1.6.0",
     "react-native-vector-icons": "^9.2.0",
     "react-native-vision-camera": "^2.15.2",
     "readable-stream": "3.6.0",
@@ -117,7 +116,6 @@
     "tty-browserify": "0.0.1",
     "url": "0.11.0",
     "util": "0.12.4",
-    "v8-android-jit": "^10.100.0",
     "vision-camera-code-scanner": "^0.2.0",
     "vm-browserify": "1.1.2"
   },

--- a/patches/@noble+hashes+1.1.5.patch
+++ b/patches/@noble+hashes+1.1.5.patch
@@ -1,0 +1,60 @@
+diff --git a/node_modules/@noble/hashes/_sha2.js b/node_modules/@noble/hashes/_sha2.js
+index e1ebc80..bcf51a2 100644
+--- a/node_modules/@noble/hashes/_sha2.js
++++ b/node_modules/@noble/hashes/_sha2.js
+@@ -9,7 +9,7 @@ function setBigUint64(view, byteOffset, value, isLE) {
+         return view.setBigUint64(byteOffset, value, isLE);
+     const _32n = BigInt(32);
+     const _u32_max = BigInt(0xffffffff);
+-    const wh = Number((value >> _32n) & _u32_max);
++    const wh = Number((value.shiftRight(_32n)) & _u32_max);
+     const wl = Number(value & _u32_max);
+     const h = isLE ? 4 : 0;
+     const l = isLE ? 0 : 4;
+diff --git a/node_modules/@noble/hashes/esm/_sha2.js b/node_modules/@noble/hashes/esm/_sha2.js
+index c9fc908..73cd257 100644
+--- a/node_modules/@noble/hashes/esm/_sha2.js
++++ b/node_modules/@noble/hashes/esm/_sha2.js
+@@ -6,7 +6,7 @@ function setBigUint64(view, byteOffset, value, isLE) {
+         return view.setBigUint64(byteOffset, value, isLE);
+     const _32n = BigInt(32);
+     const _u32_max = BigInt(0xffffffff);
+-    const wh = Number((value >> _32n) & _u32_max);
++    const wh = Number((value.shiftRight(_32n)) & _u32_max);
+     const wl = Number(value & _u32_max);
+     const h = isLE ? 4 : 0;
+     const l = isLE ? 0 : 4;
+diff --git a/node_modules/@noble/hashes/esm/package.json b/node_modules/@noble/hashes/esm/package.json
+index 1517420..0f25323 100644
+--- a/node_modules/@noble/hashes/esm/package.json
++++ b/node_modules/@noble/hashes/esm/package.json
+@@ -1,7 +1,27 @@
+ {
+   "type": "module",
+   "browser": {
+-    "crypto": false,
+-    "./crypto": "./esm/cryptoBrowser.js"
++    "crypto": "react-native-crypto",
++    "path": "path-browserify",
++    "fs": "react-native-level-fs",
++    "_stream_transform": "readable-stream/transform",
++    "_stream_readable": "readable-stream/readable",
++    "_stream_writable": "readable-stream/writable",
++    "_stream_duplex": "readable-stream/duplex",
++    "_stream_passthrough": "readable-stream/passthrough",
++    "stream": "stream-browserify",
++    "./crypto.js": "./esm/cryptoBrowser.js"
++  },
++  "react-native": {
++    "crypto": "react-native-crypto",
++    "./crypto": "./esm/cryptoBrowser.js",
++    "path": "path-browserify",
++    "fs": "react-native-level-fs",
++    "_stream_transform": "readable-stream/transform",
++    "_stream_readable": "readable-stream/readable",
++    "_stream_writable": "readable-stream/writable",
++    "_stream_duplex": "readable-stream/duplex",
++    "_stream_passthrough": "readable-stream/passthrough",
++    "stream": "stream-browserify"
+   }
+ }

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,6 @@
+# Patches
+
+This folder contains patches created using patch-package.
+
+## noble-hashes
+- Replace bit shift operators with ones from BigInteger (android compatibility)

--- a/shim.js
+++ b/shim.js
@@ -25,7 +25,7 @@ if (typeof localStorage !== 'undefined') {
 // crypto is loaded first, so it can populate global.crypto
 require('crypto');
 
-//if (typeof BigInt === 'undefined') global.BigInt = require('big-integer')
+if (typeof BigInt === 'undefined') global.BigInt = require('big-integer');
 
 // Polyfill Intl.PluralRules to support the new i18n v4 api
 import 'intl-pluralrules';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11013,11 +11013,6 @@ react-native-url-polyfill@^1.3.0:
   dependencies:
     whatwg-url-without-unicode "8.0.0-3"
 
-react-native-v8@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.npmjs.org/react-native-v8/-/react-native-v8-1.6.0.tgz#c5b676505e0735c949e4e158205255027e1bf14e"
-  integrity sha512-fZft8WsFgtEX/Soc4fwzFKItySuiwunmkq8XbFeTMXaeMltPqMohkW3fbOa3rCePCDEmE9f3guTL8O8nE1yFRw==
-
 react-native-vector-icons@^9.2.0:
   version "9.2.0"
   resolved "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-9.2.0.tgz#3c0c82e95defd274d56363cbe8fead8d53167ebd"
@@ -12676,11 +12671,6 @@ uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-v8-android-jit@^10.100.0:
-  version "10.100.1"
-  resolved "https://registry.npmjs.org/v8-android-jit/-/v8-android-jit-10.100.1.tgz#063dd25aaa3742ce347020faa31bc3d64186646b"
-  integrity sha512-W5xeoX/a28rjPCPXRJDLEi9o+DfHl9FyhbmhtuLP1LSCbPTMmOsFRkFzkz2FMS+i7S13zTq4q3Rr2GogKo1+RQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR removes the v8 engine from the android version in order to decrease the apk size.
The new size of the applications compiled without v8 are:
* `arm64-v8a`: 47MB vs 68.1MB
* `armeabi-v7a`: 38MB vs 54.9MB

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
