### PR TITLE
feat: add PostHog user identification

### DIFF
--- a/src/components/DesmosPostHogProvider/index.tsx
+++ b/src/components/DesmosPostHogProvider/index.tsx
@@ -4,6 +4,7 @@ import { useSetting } from '@recoil/settings';
 // eslint-disable-next-line import/no-unresolved
 import { POSTHOG_API_KEY } from '@env';
 import useTrackPreviouslyCreatedAccounts from 'hooks/analytics/useTrackPreviouslyCreatedAccounts';
+import useIdentifyForPreviouslyCreatedAccounts from 'hooks/analytics/useIdentifyForPreviouslyCreatedAccounts';
 
 export interface Props {
   children: React.ReactNode;
@@ -14,6 +15,7 @@ export interface Props {
  */
 const InternalPostHogComponent: React.FC<Props> = ({ children }) => {
   useTrackPreviouslyCreatedAccounts();
+  useIdentifyForPreviouslyCreatedAccounts();
 
   return <>{children}</>;
 };

--- a/src/hooks/analytics/useIdentifyForPreviouslyCreatedAccounts.ts
+++ b/src/hooks/analytics/useIdentifyForPreviouslyCreatedAccounts.ts
@@ -1,0 +1,43 @@
+import { useStoredAccountsAddresses } from '@recoil/accounts';
+import { useSetting } from '@recoil/settings';
+import { useAnalyticsStatus } from '@recoil/analytics';
+import React from 'react';
+import useIdentifyUser from 'hooks/analytics/useIdentifyUser';
+
+/**
+ * Hook to track previously created accounts, this is required in such cases
+ * where the user have imported or created accounts before the analytics
+ * feature was added.
+ */
+const useIdentifyForPreviouslyCreatedAccounts = () => {
+  const analyticsEnabled = useSetting('analyticsEnabled');
+  const storedAccountsAddresses = useStoredAccountsAddresses();
+  const [analyticsStatus, setAnalyticsStatus] = useAnalyticsStatus();
+  const identifyUser = useIdentifyUser();
+
+  React.useEffect(() => {
+    // Don't track if the analytics is disabled.
+    if (!analyticsEnabled) {
+      return;
+    }
+
+    // User creation already tracked.
+    if (analyticsStatus.userIdentified) {
+      return;
+    }
+
+    // Identify for the previously stored accounts.
+    identifyUser(storedAccountsAddresses);
+
+    setAnalyticsStatus((currVal) => ({
+      ...currVal,
+      userIdentified: true,
+    }));
+
+    // Disabled exhaustive-deps because we don't want this effect to be executed
+    // when the storedAccountsAddresses changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [analyticsEnabled, analyticsStatus.userIdentified, setAnalyticsStatus, identifyUser]);
+};
+
+export default useIdentifyForPreviouslyCreatedAccounts;

--- a/src/hooks/analytics/useIdentifyUser.ts
+++ b/src/hooks/analytics/useIdentifyUser.ts
@@ -1,6 +1,6 @@
 import { usePostHog } from 'posthog-react-native';
 import { useCallback } from 'react';
-import * as Aes from 'react-native-aes-crypto';
+import Aes from 'react-native-aes-crypto';
 
 const useIdentifyUser = () => {
   const postHog = usePostHog();
@@ -13,7 +13,7 @@ const useIdentifyUser = () => {
 
       // We collect the addresses hash to prevent association
       // of addresses between users.
-      const hashes = await Promise.all(accountsAddresses.map(Aes.sha256));
+      const hashes = await Promise.all(accountsAddresses.map((address) => Aes.sha256(address)));
       const anonymousId = postHog.getAnonymousId();
       postHog.identify(anonymousId, {
         addresses: hashes,

--- a/src/hooks/analytics/useIdentifyUser.ts
+++ b/src/hooks/analytics/useIdentifyUser.ts
@@ -1,0 +1,26 @@
+import { usePostHog } from 'posthog-react-native';
+import { useCallback } from 'react';
+import * as Aes from 'react-native-aes-crypto';
+
+const useIdentifyUser = () => {
+  const postHog = usePostHog();
+
+  return useCallback(
+    async (accountsAddresses: string[]) => {
+      if (!postHog) {
+        return;
+      }
+
+      // We collect the addresses hash to prevent association
+      // of addresses between users.
+      const hashes = await Promise.all(accountsAddresses.map(Aes.sha256));
+      const anonymousId = postHog.getAnonymousId();
+      postHog.identify(anonymousId, {
+        addresses: hashes,
+      });
+    },
+    [postHog],
+  );
+};
+
+export default useIdentifyUser;

--- a/src/recoil/accounts.ts
+++ b/src/recoil/accounts.ts
@@ -4,6 +4,7 @@ import { getMMKV, MMKVKEYS, setMMKV } from 'lib/MMKVStorage';
 import { Account } from 'types/account';
 import { deserializeAccounts } from 'lib/AccountUtils/deserialize';
 import { serializeAccounts } from 'lib/AccountUtils/serialize';
+import useIdentifyUser from 'hooks/analytics/useIdentifyUser';
 
 /**
  * An atom that holds all the accounts stored in the application.
@@ -25,6 +26,8 @@ export const accountsAppState = atom<Record<string, Account>>({
  */
 export const useStoreAccount = () => {
   const [, setAccounts] = useRecoilState(accountsAppState);
+  const identifyUser = useIdentifyUser();
+
   return React.useCallback(
     (account: Account) => {
       setAccounts((curValue) => {
@@ -32,10 +35,14 @@ export const useStoreAccount = () => {
           ...curValue,
         };
         newValue[account.address] = account;
+
+        // Identify the user with the new stored accounts.
+        identifyUser(Object.keys(newValue));
+
         return newValue;
       });
     },
-    [setAccounts],
+    [setAccounts, identifyUser],
   );
 };
 
@@ -81,6 +88,8 @@ export const useStoredAccountsNumber = () => useRecoilValue(storedAccountsNumber
  */
 export const useDeleteAccount = () => {
   const setAccounts = useSetRecoilState(accountsAppState);
+  const identifyUser = useIdentifyUser();
+
   return useCallback(
     (address: string) => {
       setAccounts((storedAccounts) => {
@@ -88,10 +97,14 @@ export const useDeleteAccount = () => {
           ...storedAccounts,
         };
         delete newValue[address];
+
+        // Identify the user with the new stored accounts.
+        identifyUser(Object.keys(newValue));
+
         return newValue;
       });
     },
-    [setAccounts],
+    [setAccounts, identifyUser],
   );
 };
 

--- a/src/recoil/analytics.ts
+++ b/src/recoil/analytics.ts
@@ -4,6 +4,7 @@ import { AnalyticsStatus } from 'types/analytics';
 
 const DefaultAnalyticsStatus: AnalyticsStatus = {
   trackedOldCreatedAccount: false,
+  userIdentified: false,
 };
 
 /**

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -7,4 +7,9 @@ export type AnalyticsStatus = {
    * before the analytics were added.
    */
   trackedOldCreatedAccount: boolean;
+  /**
+   * Indicates whether the application has identified the user
+   * for the accounts created before the analytics were added.
+   */
+  userIdentified: boolean;
 };


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR implements the PostHog user identifications, howewer since on DPM we don't have a way to have a id that uniquely identify an user between multiple devices we keep the generated anonymus id provided from PostHog and we save as properties the hash of the addresses of the accounts imported from the user.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
