### PR TITLE
fix: balance not displayed when returning to the home

### DIFF
--- a/src/hooks/staking/useAccountPendingStakingRewards.ts
+++ b/src/hooks/staking/useAccountPendingStakingRewards.ts
@@ -20,20 +20,15 @@ const useAccountPendingStakingRewards = (accountAddress?: string) => {
   }
 
   const { data, loading, error, refetch } = useQuery(GetAccountPendingRewards, {
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
     variables: {
       address,
     },
   });
 
   const convertedPendingRewards = React.useMemo(() => {
-    if (data === undefined) {
-      return undefined;
-    }
-
-    const convertedRewards: PendingReward[] = data.action_delegation_reward.map(
-      convertGraphQLPendingReward,
-    );
+    const convertedRewards: PendingReward[] =
+      data?.action_delegation_reward?.map(convertGraphQLPendingReward) ?? [];
 
     return convertedRewards;
   }, [data]);

--- a/src/hooks/staking/useAccountPendingStakingRewards.ts
+++ b/src/hooks/staking/useAccountPendingStakingRewards.ts
@@ -20,6 +20,10 @@ const useAccountPendingStakingRewards = (accountAddress?: string) => {
   }
 
   const { data, loading, error, refetch } = useQuery(GetAccountPendingRewards, {
+    // Use cache-and-network to avoid on-chain amounts sync issues.
+    // This might happen if the user returns to a screen where this hook
+    // has been used after claiming the rewards. In this case, the total
+    // amount will be different from the amount on chain.
     fetchPolicy: 'cache-and-network',
     variables: {
       address,

--- a/src/hooks/staking/useAccountRedelegationsFrom.ts
+++ b/src/hooks/staking/useAccountRedelegationsFrom.ts
@@ -21,7 +21,7 @@ const useAccountRedelegationsFrom = (validatorOperatorAddress: string, accountAd
   }
 
   const { data, loading, error, refetch } = useQuery(GetAccountRedelegations, {
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
     variables: {
       address,
     },

--- a/src/hooks/staking/useAccountRedelegationsFrom.ts
+++ b/src/hooks/staking/useAccountRedelegationsFrom.ts
@@ -21,6 +21,10 @@ const useAccountRedelegationsFrom = (validatorOperatorAddress: string, accountAd
   }
 
   const { data, loading, error, refetch } = useQuery(GetAccountRedelegations, {
+    // Use cache-and-network to avoid on-chain sync issues.
+    // This might happen if the user returns to a screen where this hook
+    // has been used after performing a redelegation. In this case, the redelegations
+    // will be different from the on chain redelegations.
     fetchPolicy: 'cache-and-network',
     variables: {
       address,

--- a/src/hooks/staking/useTotalDelegatedAmount.ts
+++ b/src/hooks/staking/useTotalDelegatedAmount.ts
@@ -24,18 +24,15 @@ const useTotalDelegatedAmount = (userAddress?: string) => {
     variables: {
       address,
     },
-    // Use network-only to avoid on-chain amounts sync issues.
+    // Use cache-and-network to avoid on-chain amounts sync issues.
     // This might happen if the user returns to a screen where this hook
     // has been used after performing a delegation. In this case, the total
     // amount will be different from the amount staked on chain.
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
   });
 
   const totalDelegated = React.useMemo(() => {
-    if (loading || error || data === undefined) {
-      return undefined;
-    }
-    const converted: Coin[] = data.action_delegation_total.coins.map((c: any) =>
+    const converted: Coin[] = data?.action_delegation_total?.coins.map((c: any) =>
       coin(c.amount, c.denom),
     );
 
@@ -44,7 +41,7 @@ const useTotalDelegatedAmount = (userAddress?: string) => {
       converted.push(coin(0, chainInfo.stakeCurrency.coinMinimalDenom));
     }
     return converted;
-  }, [chainInfo.stakeCurrency.coinMinimalDenom, data, error, loading]);
+  }, [chainInfo.stakeCurrency.coinMinimalDenom, data]);
 
   return {
     totalDelegated,

--- a/src/hooks/staking/useTotalRedelegatingAmount.ts
+++ b/src/hooks/staking/useTotalRedelegatingAmount.ts
@@ -28,6 +28,10 @@ const useTotalRedelegatingAmount = (userAddress?: string) => {
   }
 
   const [fetchRedelegations] = useLazyQuery(GetAccountRedelegations, {
+    // Use cache-and-network to avoid on-chain amounts sync issues.
+    // This might happen if the user returns to a screen where this hook
+    // has been used after doing a redelegation. In this case, the total
+    // amount will be different from the amount on chain.
     fetchPolicy: 'cache-and-network',
   });
 

--- a/src/hooks/staking/useTotalRedelegatingAmount.ts
+++ b/src/hooks/staking/useTotalRedelegatingAmount.ts
@@ -28,7 +28,7 @@ const useTotalRedelegatingAmount = (userAddress?: string) => {
   }
 
   const [fetchRedelegations] = useLazyQuery(GetAccountRedelegations, {
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
   });
 
   const fetchAllRedelegations = React.useCallback(async () => {

--- a/src/hooks/staking/useTotalUnbondingAmount.ts
+++ b/src/hooks/staking/useTotalUnbondingAmount.ts
@@ -24,11 +24,11 @@ const useTotalDelegatedAmount = (userAddress?: string) => {
     variables: {
       address,
     },
-    // Use network-only in order to avoid any inconsistency with on-chain data.
+    // Use cache-and-network in order to avoid any inconsistency with on-chain data.
     // This might happen if the user returns to a screen where this hook
     // has been used after performing an unbonding action. In this case the total
     // amount shown will be different from the amount staked on chain.
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
   });
 
   const totalUnbonding = React.useMemo(() => {

--- a/src/hooks/staking/useValidatorStakedAmount.ts
+++ b/src/hooks/staking/useValidatorStakedAmount.ts
@@ -24,6 +24,10 @@ const useValidatorStakedAmount = (validatorOperatorAddress: string, accountAddre
   }
 
   const { data, loading, error, refetch } = useQuery(GetAccountDelegations, {
+    // Use cache-and-network to avoid on-chain amounts sync issues.
+    // This might happen if the user returns to a screen where this hook
+    // has been used after delegating or redelegating some tokens.
+    // In those cases, the total amount will be different from the amount on chain.
     fetchPolicy: 'cache-and-network',
     variables: {
       address,

--- a/src/hooks/staking/useValidatorStakedAmount.ts
+++ b/src/hooks/staking/useValidatorStakedAmount.ts
@@ -24,7 +24,7 @@ const useValidatorStakedAmount = (validatorOperatorAddress: string, accountAddre
   }
 
   const { data, loading, error, refetch } = useQuery(GetAccountDelegations, {
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
     variables: {
       address,
     },

--- a/src/hooks/staking/useValidatorUnbondingDelegations.ts
+++ b/src/hooks/staking/useValidatorUnbondingDelegations.ts
@@ -25,7 +25,7 @@ const useValidatorUnbondingDelegations = (
   }
 
   const { data, loading, error, refetch } = useQuery(GetAccountUnbondingDelegations, {
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
     variables: {
       address,
     },

--- a/src/hooks/staking/useValidatorUnbondingDelegations.ts
+++ b/src/hooks/staking/useValidatorUnbondingDelegations.ts
@@ -25,6 +25,10 @@ const useValidatorUnbondingDelegations = (
   }
 
   const { data, loading, error, refetch } = useQuery(GetAccountUnbondingDelegations, {
+    // Use cache-and-network to avoid on-chain sync issues.
+    // This might happen if the user returns to a screen where this hook
+    // has been used after unbonding some tokens. In this case, the unbonding
+    // delegations will be different from the ones on chain.
     fetchPolicy: 'cache-and-network',
     variables: {
       address,

--- a/src/hooks/useActiveAccountTransactions.ts
+++ b/src/hooks/useActiveAccountTransactions.ts
@@ -26,6 +26,7 @@ const useActiveAccountTransactions = () => {
 
   const { data, loading, fetchMore, refetch } = useQuery(GetTransactionsByAddress, {
     variables: getQueryVariables(address, 0),
+    fetchPolicy: 'cache-and-network',
   });
 
   const transactions: GroupedTransactions[] | undefined = React.useMemo(


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR fixes a bug where the balances are not displayed when returning to the home.
Ti bug was caused from the fact that the server was returning an error related to the query of data in a block that has yet to be produced.
To fix this I leveregd the apollo cache so that the application now gently fallback to the last fetched data, in this case the app will just show a non up to date information instead of nothing, the information can be later updated from the user with the pull to refresh gesture. This also have the benefit of making the UI showing the content loaders since the `loading` flag of apollo will correctly refelect the status of the request unlike before.
This is the final result:
![screen-20230526-164230 mp4](https://github.com/desmos-labs/dpm/assets/6245917/75b83fcf-e389-45cf-9a74-7ed23530b1bf)

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
