### PR TITLE
fix: fix splash screen loading crash

### DIFF
--- a/patches/react-native-bootsplash+4.4.1.patch
+++ b/patches/react-native-bootsplash+4.4.1.patch
@@ -1,0 +1,64 @@
+--- a/node_modules/react-native-bootsplash/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModule.java
++++ b/node_modules/react-native-bootsplash/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModule.java
+@@ -72,33 +72,34 @@ public class RNBootSplashModule extends ReactContextBaseJavaModule {
+       }
+     });
+
+-    mSplashScreen.setOnExitAnimationListener(new SplashScreen.OnExitAnimationListener() {
+-      @Override
+-      public void onSplashScreenExit(@NonNull final SplashScreenViewProvider splashScreenViewProvider) {
+-        final View splashScreenView = splashScreenViewProvider.getView();
+-
+-        splashScreenView
+-          .animate()
+-          // Crappy hack to avoid automatic layout transitions
+-          .setDuration(mShouldFade ? mAnimationDuration: 0)
+-          .setStartDelay(mShouldFade ? 0 : mAnimationDuration)
+-          .alpha(0.0f)
+-          .setInterpolator(new AccelerateInterpolator())
+-          .setListener(new AnimatorListenerAdapter() {
+-            @Override
+-            public void onAnimationEnd(Animator animation) {
+-              super.onAnimationEnd(animation);
+-
+-              if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+-                splashScreenViewProvider.remove();
+-              } else {
+-                // Avoid calling applyThemesSystemBarAppearance
+-                ((SplashScreenView) splashScreenView).remove();
+-              }
+-            }
+-          }).start();
+-      }
+-    });
++    // Disabled fade out animation to avoid crashe on Android > 12
++    //mSplashScreen.setOnExitAnimationListener(new SplashScreen.OnExitAnimationListener() {
++    //  @Override
++    //  public void onSplashScreenExit(@NonNull final SplashScreenViewProvider splashScreenViewProvider) {
++    //    final View splashScreenView = splashScreenViewProvider.getView();
++    //
++    //    splashScreenView
++    //      .animate()
++    //      // Crappy hack to avoid automatic layout transitions
++    //      .setDuration(mShouldFade ? mAnimationDuration: 0)
++    //      .setStartDelay(mShouldFade ? 0 : mAnimationDuration)
++    //      .alpha(0.0f)
++    //      .setInterpolator(new AccelerateInterpolator())
++    //      .setListener(new AnimatorListenerAdapter() {
++    //        @Override
++    //        public void onAnimationEnd(Animator animation) {
++    //          super.onAnimationEnd(animation);
++    //
++    //          if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
++    //            splashScreenViewProvider.remove();
++    //          } else {
++    //            // Avoid calling applyThemesSystemBarAppearance
++    //            ((SplashScreenView) splashScreenView).remove();
++    //          }
++    //        }
++    //      }).start();
++    //  }
++    // });
+   }
+
+   private void clearPromiseQueue() {


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR fixes a crash on Android when the application is closed during the visualization of the splash screen and immediately reopened.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
