### PR TITLE
feat: improve transaction fee estimation functionality

### DIFF
--- a/src/assets/locales/en/transaction.json
+++ b/src/assets/locales/en/transaction.json
@@ -14,5 +14,5 @@
   "from": "From",
   "memo": "Note (Memo)",
   "memo placeholder": "Description (optional)",
-  "computing fee": "Computing fee"
+  "computing fee": "Calculating fee"
 }

--- a/src/assets/locales/en/transaction.json
+++ b/src/assets/locales/en/transaction.json
@@ -13,5 +13,6 @@
   "to": "To",
   "from": "From",
   "memo": "Note (Memo)",
-  "memo placeholder": "Description (optional)"
+  "memo placeholder": "Description (optional)",
+  "computing fee": "Computing fee"
 }

--- a/src/components/DesmosPostHogProvider/index.tsx
+++ b/src/components/DesmosPostHogProvider/index.tsx
@@ -4,6 +4,7 @@ import { PostHogProvider } from 'posthog-react-native';
 import { POSTHOG_API_KEY } from '@env';
 import useTrackPreviouslyCreatedAccounts from 'hooks/analytics/useTrackPreviouslyCreatedAccounts';
 import useTrackAppOpened from 'hooks/analytics/useTrackAppOpened';
+import { DefaultPosthogFeatureFlags } from 'types/appFeatureFlags';
 
 export interface Props {
   children: React.ReactNode;
@@ -23,6 +24,9 @@ const DesmosPostHogProvider: React.FC<Props> = ({ children }) => (
     apiKey={POSTHOG_API_KEY}
     options={{
       host: 'https://app.posthog.com',
+      bootstrap: {
+        featureFlags: DefaultPosthogFeatureFlags,
+      },
     }}
     debug={__DEV__}
     autocapture={{

--- a/src/components/FeatureFlags/index.ts
+++ b/src/components/FeatureFlags/index.ts
@@ -1,0 +1,24 @@
+import {
+  AppFeatureFlags,
+  DefaultPosthogFeatureFlags,
+  PostHogFeatureFlags,
+} from 'types/appFeatureFlags';
+
+/**
+ * Function to convert the feature flags received from posthog into
+ * a format that the application can use.
+ * @param featureFlags - The feature flags received from Posthog.
+ */
+export const convertPostHogFeatureFlags = (
+  featureFlags: PostHogFeatureFlags | undefined,
+): AppFeatureFlags => {
+  const safeFeatureFlags = {
+    ...DefaultPosthogFeatureFlags,
+    ...featureFlags,
+  };
+  return {
+    trackFeeEstimation: safeFeatureFlags.trackFeeEstimation,
+    feeEstimationTimeoutMs: parseInt(safeFeatureFlags.feeEstimationTimeoutMs, 10),
+    gasOnFeeEstimationTimeout: parseInt(safeFeatureFlags.gasOnFeeEstimationTimeout, 10),
+  };
+};

--- a/src/components/TransactionDetails/index.tsx
+++ b/src/components/TransactionDetails/index.tsx
@@ -28,7 +28,7 @@ export type TransactionDetailsProps = {
    * Tells if the fee have been approximated.
    * If this field is true will be show a `~`
    * before the fee amount to inform the user that the
-   * fees have been approximated.
+   * fee have been approximated.
    */
   approximatedFee?: boolean;
   /**

--- a/src/components/TransactionDetails/index.tsx
+++ b/src/components/TransactionDetails/index.tsx
@@ -26,9 +26,9 @@ export type TransactionDetailsProps = {
   fee?: StdFee | Fee;
   /**
    * Tells if the fee have been approximated.
-   * If this field is true will be show a `~`
-   * before the fee amount to inform the user that the
-   * fee have been approximated.
+   * If this field is true, the user will see a `~`
+   * before the fee amount to easily understand that the
+   * fees have been approximated.
    */
   approximatedFee?: boolean;
   /**

--- a/src/components/TransactionDetails/index.tsx
+++ b/src/components/TransactionDetails/index.tsx
@@ -17,13 +17,20 @@ export type TransactionDetailsProps = {
    */
   messages: readonly EncodeObject[];
   /**
-   * True if the fees are still being estimaded.
+   * True if the fees are still being estimated.
    */
   estimatingFee?: boolean;
   /**
    * Fees to be shown to the user.
    */
   fee?: StdFee | Fee;
+  /**
+   * Tells if the fee have been approximated.
+   * If this field is true will be show a `~`
+   * before the fee amount to inform the user that the
+   * fees have been approximated.
+   */
+  approximatedFee?: boolean;
   /**
    * Memo associated with the transaction.
    */
@@ -43,9 +50,12 @@ const TransactionDetails: React.FC<TransactionDetailsProps> = (props) => {
   const { t } = useTranslation('transaction');
   const styles = useStyles();
 
-  const { memo, messages, fee, success, dateTime, style, estimatingFee } = props;
+  const { memo, messages, fee, success, dateTime, style, estimatingFee, approximatedFee } = props;
 
-  const txFex = useMemo(() => formatCoins(fee?.amount), [fee]);
+  const txFex = useMemo(() => {
+    const formattedCoins = formatCoins(fee?.amount);
+    return approximatedFee ? `~${formattedCoins}` : formattedCoins;
+  }, [approximatedFee, fee?.amount]);
 
   return (
     <View style={styles.root}>

--- a/src/hooks/featureflags/useAppFeatureFlags.ts
+++ b/src/hooks/featureflags/useAppFeatureFlags.ts
@@ -1,0 +1,17 @@
+import { useFeatureFlags } from 'posthog-react-native';
+import React from 'react';
+import { convertPostHogFeatureFlags } from 'components/FeatureFlags';
+
+/**
+ * Hook that provides the application feature flags.
+ */
+const useAppFeatureFlags = () => {
+  const postHogFeatureFlags = useFeatureFlags();
+
+  return React.useMemo(
+    () => convertPostHogFeatureFlags(postHogFeatureFlags),
+    [postHogFeatureFlags],
+  );
+};
+
+export default useAppFeatureFlags;

--- a/src/lib/LedgerUtils/commands.ts
+++ b/src/lib/LedgerUtils/commands.ts
@@ -2,14 +2,7 @@ import BluetoothTransport from '@ledgerhq/react-native-hw-transport-ble';
 import { err, Result, ResultAsync } from 'neverthrow';
 import { convertErrorToLedgerError, isUnknownLedgerError } from 'lib/LedgerUtils/errors';
 import { ApplicationOpenRejectedError, LedgerError } from 'types/ledger';
-
-async function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, ms);
-  });
-}
+import { delay } from 'lib/PromiseUtils';
 
 /**
  * Establish a connection to a Ledger device.

--- a/src/lib/PromiseUtils/index.ts
+++ b/src/lib/PromiseUtils/index.ts
@@ -1,0 +1,15 @@
+export * from './timeout';
+
+/**
+ * Creates a promise that resolves after the specified amount of
+ * milliseconds.
+ * @param ms - The amount of milliseconds that the created promise will wait
+ * before resolving.
+ */
+export async function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}

--- a/src/lib/PromiseUtils/timeout.test.ts
+++ b/src/lib/PromiseUtils/timeout.test.ts
@@ -1,0 +1,47 @@
+import { completed, CompletedResult, delay, PromiseTimeout, timedOut } from 'lib/PromiseUtils';
+
+describe('PromiseTimeout', () => {
+  it('on completed resolves a CompletedResult', async () => {
+    const testPromise = delay(1000).then(() => 42);
+    const wrappedResult = await PromiseTimeout.wrap(testPromise, 2000);
+
+    expect(wrappedResult.isCompleted()).toBe(true);
+    expect((wrappedResult as CompletedResult<number>).data).toBe(42);
+  });
+
+  it('on timeout resolves to TimedOutResult', async () => {
+    const testPromise = delay(2000).then(() => 42);
+    const wrappedResult = await PromiseTimeout.wrap(testPromise, 1000);
+
+    expect(wrappedResult.isTimedOut()).toBe(true);
+  });
+
+  it('onTimeoutFallback provides the fallback value', async () => {
+    const testPromise = delay(2000).then(() => 42);
+    const result = await PromiseTimeout.wrap(testPromise, 1000).onTimeoutFallback(1337);
+
+    expect(result).toBe(1337);
+  });
+
+  it('onTimeoutFallback catches the errors', async () => {
+    const testPromise = new Promise((resolve, reject) => {
+      reject(new Error('test error'));
+    });
+    const result = await PromiseTimeout.wrap(testPromise, 1000).onTimeoutFallback(1337, true);
+
+    expect(result).toBe(1337);
+  });
+
+  it('CompletedResult implements the ResultI correctly', () => {
+    const completedResult = completed(42);
+    expect(completedResult.isCompleted()).toBe(true);
+    expect(completedResult.isTimedOut()).toBe(false);
+    expect(completedResult.data).toBe(42);
+  });
+
+  it('TimedOutResult implements the ResultI correctly', () => {
+    const completedResult = timedOut();
+    expect(completedResult.isCompleted()).toBe(false);
+    expect(completedResult.isTimedOut()).toBe(true);
+  });
+});

--- a/src/lib/PromiseUtils/timeout.test.ts
+++ b/src/lib/PromiseUtils/timeout.test.ts
@@ -16,6 +16,13 @@ describe('PromiseTimeout', () => {
     expect(wrappedResult.isTimedOut()).toBe(true);
   });
 
+  it('onTimeoutFallback provides the computed value', async () => {
+    const testPromise = delay(1000).then(() => 42);
+    const result = await PromiseTimeout.wrap(testPromise, 2000).onTimeoutFallback(1337);
+
+    expect(result).toBe(42);
+  });
+
   it('onTimeoutFallback provides the fallback value', async () => {
     const testPromise = delay(2000).then(() => 42);
     const result = await PromiseTimeout.wrap(testPromise, 1000).onTimeoutFallback(1337);
@@ -30,6 +37,27 @@ describe('PromiseTimeout', () => {
     const result = await PromiseTimeout.wrap(testPromise, 1000).onTimeoutFallback(1337, true);
 
     expect(result).toBe(1337);
+  });
+
+  it('correctly call catch if the wrapped promise fails', async () => {
+    const testPromise = new Promise((resolve, reject) => {
+      reject(new Error('test error'));
+    });
+    const result = await PromiseTimeout.wrap(testPromise, 1000).catch(() => 42);
+
+    expect(result).toBe(42);
+  });
+
+  it('correctly call finally', async () => {
+    const testFn = jest.fn();
+    const testPromise = new Promise((resolve, reject) => {
+      reject(new Error('test error'));
+    });
+    await PromiseTimeout.wrap(testPromise, 1000)
+      .catch(() => 42)
+      .finally(testFn);
+
+    expect(testFn.mock.calls.length).toBe(1);
   });
 
   it('CompletedResult implements the ResultI correctly', () => {

--- a/src/lib/PromiseUtils/timeout.ts
+++ b/src/lib/PromiseUtils/timeout.ts
@@ -1,0 +1,151 @@
+// eslint-disable-next-line max-classes-per-file
+import { delay } from 'lib/PromiseUtils/index';
+
+/**
+ * Class that represents the result of a completed promise
+ * within a specified timeout duration.
+ */
+export class CompletedResult<T> implements ResultI<T> {
+  readonly resultData: T;
+
+  constructor(data: T) {
+    this.resultData = data;
+  }
+
+  /**
+   * Gets the computed data.
+   */
+  get data(): T {
+    return this.resultData;
+  }
+
+  isCompleted(): this is CompletedResult<T> {
+    return true;
+  }
+
+  isTimedOut(): this is TimedOutResult<T> {
+    return false;
+  }
+}
+
+/**
+ * Utility function to construct a `CompletedResult`.
+ * @param data - Data that has been computed.
+ */
+export function completed<T>(data: T): CompletedResult<T> {
+  return new CompletedResult(data);
+}
+
+/**
+ * Class that represents the result when a promise
+ * does not resolve within a timeout duration.
+ */
+export class TimedOutResult<T> implements ResultI<T> {
+  isCompleted(): this is CompletedResult<T> {
+    return false;
+  }
+
+  isTimedOut(): this is TimedOutResult<T> {
+    return true;
+  }
+}
+
+/**
+ * Utility function to construct a `TimedOutResult`.
+ */
+export function timedOut<T>(): TimedOutResult<T> {
+  return new TimedOutResult();
+}
+
+/**
+ * Interface that represents a result from a computation that
+ * have a timeout.
+ */
+interface ResultI<T> {
+  /**
+   * Checks if the computation completed correctly.
+   *
+   * @returns `true` if the result represents a completed computation,
+   * `false` otherwise.
+   */
+  isCompleted(): this is CompletedResult<T>;
+
+  /**
+   * Checks if the computation timed out.
+   *
+   * @returns `true` if the result represents a computation that timed out,
+   * `false` otherwise.
+   */
+  isTimedOut(): this is TimedOutResult<T>;
+}
+
+/**
+ * Type that represents the result of an operation that involves a timeout.
+ * It can hold either a `CompletedResult` or a `TimedOutResult` object.
+ */
+export type TimeoutResult<T> = CompletedResult<T> | TimedOutResult<T>;
+
+/**
+ * Class that wraps a promise to implement a timeout logic so that
+ * a promise can complete correctly or complete with a timeout.
+ */
+export class PromiseTimeout<T> implements Promise<TimeoutResult<T>> {
+  // Field used from the toString function to represent this type.
+  [Symbol.toStringTag]: string;
+
+  // The wrapped promise.
+  private promise: Promise<TimeoutResult<T>>;
+
+  private constructor(promise: Promise<T>, timeoutMs: number) {
+    this[Symbol.toStringTag] = 'PromiseTimeout';
+    this.promise = Promise.race<Promise<TimeoutResult<T>>>([
+      promise.then(completed),
+      delay(timeoutMs).then(() => timedOut()),
+    ]);
+  }
+
+  /**
+   * Wraps a promise and construct a `TimeoutPromise`.
+   * @param promise - The promise to wrap.
+   * @param timeoutMs - Amount of ms to wait before considering the
+   * promise as timed out.
+   */
+  static wrap<T>(promise: Promise<T>, timeoutMs: number) {
+    return new PromiseTimeout(promise, timeoutMs);
+  }
+
+  /**
+   * Function to resolve the wrapped promise with a provided value
+   * on time out.
+   * @param fallbackValue - Fallback value that will be resolved if the
+   * wrapped promise times out.
+   * @param catchErrors - Optional flag to consider the thrown errors as
+   * an execution that timed out.
+   */
+  async onTimeoutFallback(fallbackValue: T, catchErrors?: boolean): Promise<T> {
+    const promise = this.then((result) => {
+      if (result.isCompleted()) {
+        return result.data;
+      }
+      return fallbackValue;
+    });
+    return catchErrors ? promise.catch(() => fallbackValue) : promise;
+  }
+
+  then<TResult1 = TimeoutResult<T>, TResult2 = never>(
+    onfulfilled?: ((value: TimeoutResult<T>) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return this.promise.then(onfulfilled, onrejected);
+  }
+
+  catch<TResult = never>(
+    onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null,
+  ): Promise<TimeoutResult<T> | TResult> {
+    return this.promise.catch(onrejected);
+  }
+
+  finally(onfinally?: (() => void) | null): Promise<TimeoutResult<T>> {
+    return this.promise.finally(onfinally);
+  }
+}

--- a/src/lib/Timer/index.ts
+++ b/src/lib/Timer/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Class that represents a timer that can be used
+ * to compute time differences.
+ */
+export class Timer {
+  startTime: Date;
+
+  /**
+   * Construct the timer and starts it.
+   */
+  constructor() {
+    this.startTime = new Date();
+  }
+
+  /**
+   * Get the difference in milliseconds from when the
+   * timer has been started.
+   */
+  currentMs(): number {
+    const now = new Date();
+    return now.getTime() - this.startTime.getTime();
+  }
+
+  /**
+   * Restart the timer.
+   */
+  reset() {
+    this.startTime = new Date();
+  }
+}

--- a/src/screens/BroadcastTx/hooks.ts
+++ b/src/screens/BroadcastTx/hooks.ts
@@ -15,10 +15,10 @@ import useAppFeatureFlags from 'hooks/featureflags/useAppFeatureFlags';
 import { usePostHog } from 'posthog-react-native';
 import { Timer } from 'lib/Timer';
 
-export const useEstimateFees = () => {
-  const [estimatingFees, setEstimatingFees] = useState(false);
+export const useEstimateFee = () => {
+  const [estimatingFee, setEstimatingFee] = useState(false);
   const [areFeeApproximated, setAreFeeApproximated] = useState(false);
-  const [estimatedFees, setEstimatedFees] = useState<StdFee>();
+  const [estimatedFee, setEstimatedFee] = useState<StdFee>();
   const activeAccount = useActiveAccount()!;
   const chainInfo = useCurrentChainInfo();
   const gasPrice = useCurrentChainGasPrice();
@@ -28,9 +28,9 @@ export const useEstimateFees = () => {
 
   const estimateFees = useCallback(
     async (messages: EncodeObject[], memo: string = '') => {
-      setEstimatingFees(true);
+      setEstimatingFee(true);
       setAreFeeApproximated(false);
-      setEstimatedFees(undefined);
+      setEstimatedFee(undefined);
 
       // Compute a fallback fee amount.
       const fallbackFee = calculateFee(gasOnFeeEstimationTimeout, gasPrice!);
@@ -58,7 +58,7 @@ export const useEstimateFees = () => {
       // Get the current timer value in ms.
       const executionTime = timer.currentMs();
 
-      let estimatedFee: StdFee;
+      let computedFee: StdFee;
       if (feeEstimationResult.isOk()) {
         // The fee estimation completed without errors.
         const timeoutResult = feeEstimationResult.value;
@@ -71,22 +71,23 @@ export const useEstimateFees = () => {
               'Estimation Time Milliseconds': executionTime,
             });
           }
-          estimatedFee = timeoutResult.data;
+          computedFee = timeoutResult.data;
         } else {
           if (trackFeeEstimation) {
             postHog?.capture('Transaction Fee Estimation Timeout');
           }
-          estimatedFee = fallbackFee;
+          computedFee = fallbackFee;
         }
       } else {
-        estimatedFee = fallbackFee;
+        computedFee = fallbackFee;
       }
 
-      setEstimatedFees(estimatedFee);
-      setAreFeeApproximated(estimatedFee === fallbackFee);
-      setEstimatingFees(false);
+      setEstimatedFee(computedFee);
+      setAreFeeApproximated(computedFee === fallbackFee);
+      setEstimatingFee(false);
     },
     [
+      trackFeeEstimation,
       activeAccount,
       chainInfo.rpcUrl,
       feeEstimationTimeoutMs,
@@ -98,9 +99,9 @@ export const useEstimateFees = () => {
 
   return {
     estimateFees,
-    estimatingFees,
+    estimatingFee,
     areFeeApproximated,
-    estimatedFees,
+    estimatedFee,
   };
 };
 

--- a/src/screens/BroadcastTx/index.tsx
+++ b/src/screens/BroadcastTx/index.tsx
@@ -71,7 +71,7 @@ const BroadcastTx: React.FC<NavProps> = (props) => {
 
   const broadcastTx = useSignAndBroadcastTx();
   const showModal = useShowModal();
-  const { estimateFees, estimatingFees, estimatedFees } = useEstimateFees();
+  const { estimateFees, estimatingFees, areFeeApproximated, estimatedFees } = useEstimateFees();
 
   const [broadcastingTx, setBroadcastingTx] = useState(false);
   const [broadcastTxStatus, setBroadcastTxStatus] = useState<BroadcastTxStatus>({
@@ -81,6 +81,16 @@ const BroadcastTx: React.FC<NavProps> = (props) => {
   useEffect(() => {
     estimateFees(messages, memo);
   }, [estimateFees, memo, messages]);
+
+  const buttonText = React.useMemo(() => {
+    if (estimatingFees) {
+      return t('computing fee');
+    }
+    if (broadcastingTx) {
+      return t('broadcasting tx');
+    }
+    return t('common:confirm');
+  }, [t, estimatingFees, broadcastingTx]);
 
   useOnScreenDetached(() => {
     switch (broadcastTxStatus.status) {
@@ -153,15 +163,16 @@ const BroadcastTx: React.FC<NavProps> = (props) => {
         memo={memo}
         estimatingFee={estimatingFees}
         fee={estimatedFees}
+        approximatedFee={areFeeApproximated}
       />
       <Button
         style={styles.nextBtn}
         mode="contained"
         onPress={confirmBroadcast}
-        loading={broadcastingTx}
+        loading={broadcastingTx || estimatingFees}
         disabled={broadcastingTx || estimatingFees}
       >
-        {!broadcastingTx ? t('common:confirm') : t('broadcasting tx')}
+        {buttonText}
       </Button>
     </StyledSafeAreaView>
   );

--- a/src/screens/BroadcastTx/index.tsx
+++ b/src/screens/BroadcastTx/index.tsx
@@ -10,7 +10,7 @@ import Button from 'components/Button';
 import { RootNavigatorParamList } from 'navigation/RootNavigator';
 import ROUTES from 'navigation/routes';
 import { EncodeObject } from '@cosmjs/proto-signing';
-import { useEstimateFees, useSignAndBroadcastTx } from 'screens/BroadcastTx/hooks';
+import { useEstimateFee, useSignAndBroadcastTx } from 'screens/BroadcastTx/hooks';
 import { DPMImages } from 'types/images';
 import { DeliverTxResponse } from '@desmoslabs/desmjs';
 import useOnScreenDetached from 'hooks/useOnScreenDetached';
@@ -71,7 +71,7 @@ const BroadcastTx: React.FC<NavProps> = (props) => {
 
   const broadcastTx = useSignAndBroadcastTx();
   const showModal = useShowModal();
-  const { estimateFees, estimatingFees, areFeeApproximated, estimatedFees } = useEstimateFees();
+  const { estimateFees, estimatingFee, areFeeApproximated, estimatedFee } = useEstimateFee();
 
   const [broadcastingTx, setBroadcastingTx] = useState(false);
   const [broadcastTxStatus, setBroadcastTxStatus] = useState<BroadcastTxStatus>({
@@ -83,14 +83,14 @@ const BroadcastTx: React.FC<NavProps> = (props) => {
   }, [estimateFees, memo, messages]);
 
   const buttonText = React.useMemo(() => {
-    if (estimatingFees) {
+    if (estimatingFee) {
       return t('computing fee');
     }
     if (broadcastingTx) {
       return t('broadcasting tx');
     }
     return t('common:confirm');
-  }, [t, estimatingFees, broadcastingTx]);
+  }, [t, estimatingFee, broadcastingTx]);
 
   useOnScreenDetached(() => {
     switch (broadcastTxStatus.status) {
@@ -136,9 +136,9 @@ const BroadcastTx: React.FC<NavProps> = (props) => {
   );
 
   const confirmBroadcast = React.useCallback(async () => {
-    if (estimatedFees !== undefined) {
+    if (estimatedFee !== undefined) {
       setBroadcastingTx(true);
-      const broadcastResult = await broadcastTx(messages, estimatedFees, memo);
+      const broadcastResult = await broadcastTx(messages, estimatedFee, memo);
       if (broadcastResult.isOk()) {
         const deliveredTx = broadcastResult.value;
         if (deliveredTx !== undefined) {
@@ -154,23 +154,23 @@ const BroadcastTx: React.FC<NavProps> = (props) => {
       }
       setBroadcastingTx(false);
     }
-  }, [broadcastTx, estimatedFees, memo, messages, showErrorModal, showSuccessModal]);
+  }, [broadcastTx, estimatedFee, memo, messages, showErrorModal, showSuccessModal]);
 
   return (
     <StyledSafeAreaView topBar={<TopBar stackProps={props} title={t('tx details')} />}>
       <TransactionDetails
         messages={messages}
         memo={memo}
-        estimatingFee={estimatingFees}
-        fee={estimatedFees}
+        estimatingFee={estimatingFee}
+        fee={estimatedFee}
         approximatedFee={areFeeApproximated}
       />
       <Button
         style={styles.nextBtn}
         mode="contained"
         onPress={confirmBroadcast}
-        loading={broadcastingTx || estimatingFees}
-        disabled={broadcastingTx || estimatingFees}
+        loading={broadcastingTx || estimatingFee}
+        disabled={broadcastingTx || estimatingFee}
       >
         {buttonText}
       </Button>

--- a/src/screens/DevScreen/index.tsx
+++ b/src/screens/DevScreen/index.tsx
@@ -12,6 +12,8 @@ import SingleButtonModal from 'modals/SingleButtonModal';
 import { DPMImages } from 'types/images';
 import * as Sentry from '@sentry/react-native';
 import { ModalMode } from 'modals/ModalScreen';
+import Typography from 'components/Typography';
+import useAppFeatureFlags from 'hooks/featureflags/useAppFeatureFlags';
 import useStyles from './useStyles';
 
 enum DevRoutes {
@@ -41,6 +43,7 @@ const DevScreen: FC<NavProps> = ({ navigation }) => {
   const styles = useStyles();
   const postHog = usePostHog()!;
   const showModal = useShowModal();
+  const appFeatureFlags = useAppFeatureFlags();
 
   const itemSeparator = React.useCallback(() => <Spacer paddingVertical={4} />, []);
 
@@ -121,6 +124,12 @@ const DevScreen: FC<NavProps> = ({ navigation }) => {
         renderItem={renderItem}
         ItemSeparatorComponent={itemSeparator}
       />
+
+      <Spacer paddingVertical={4} />
+
+      {/* Display the current application feature flags */}
+      <Typography.Subtitle>Feature flags</Typography.Subtitle>
+      <Typography.Caption>{JSON.stringify(appFeatureFlags, undefined, 4)}</Typography.Caption>
 
       <Spacer paddingVertical={4} />
 

--- a/src/types/appFeatureFlags.ts
+++ b/src/types/appFeatureFlags.ts
@@ -1,0 +1,41 @@
+/**
+ * Interface that represents the feature flags supported from the application.
+ */
+export interface AppFeatureFlags {
+  /**
+   * Feature flag that tells if the application should track
+   * the fee estimation procedure.
+   */
+  trackFeeEstimation: boolean;
+  /**
+   * Max amount of milliseconds that we wait
+   * to compute the fees of a transaction before
+   * falling back to a default value.
+   */
+  feeEstimationTimeoutMs: number;
+  /**
+   * Gas that will be used to estimate the fees
+   * of a transaction if the estimation procedure
+   * times out.
+   */
+  gasOnFeeEstimationTimeout: number;
+}
+
+/**
+ * Interface that represents the feature flags returned
+ * from posthog.
+ */
+export interface PostHogFeatureFlags extends Record<keyof AppFeatureFlags, string | boolean> {
+  trackFeeEstimation: boolean;
+  feeEstimationTimeoutMs: string;
+  gasOnFeeEstimationTimeout: string;
+}
+
+/**
+ * Default feature flags values if not provided from posthog.
+ */
+export const DefaultPosthogFeatureFlags: PostHogFeatureFlags = {
+  trackFeeEstimation: false,
+  feeEstimationTimeoutMs: '5000',
+  gasOnFeeEstimationTimeout: '200000',
+};


### PR DESCRIPTION
## Description

Closes: DPM-73, DPM-72

This PR improves the fee estimation procedure by enforcing a timeout that if exceed the application will fallback to a default fee value.
The default fee amount and allowed execution time can be configured with some feature flags from Posthog.
On top of this I have added an analytics to track the amount of time that the application is abble to correctly estimate the fee in the provided time to be able to tune the timeout value. This analytics can be enabled/disbale through a Posthog feature flag.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
