### PR TITLE
fix: mnemonic input not allowing the user to write if the first letter is uppercase

### DIFF
--- a/src/screens/ImportAccountFromMnemonic/index.tsx
+++ b/src/screens/ImportAccountFromMnemonic/index.tsx
@@ -28,19 +28,24 @@ const ImportAccountFromMnemonic: FC<NavProps> = (props) => {
   const styles = useStyles();
   const { t } = useTranslation('account');
 
-  const selectAccount = useSelectAccount();
+  // -------- HOOKS --------
 
+  const selectAccount = useSelectAccount();
   const importAccountState = useRecoilValue(importAccountAppState);
   const { ignoreAddresses, selectedChain, onSuccess } = importAccountState!;
+
+  // -------- STATES --------
 
   const [mnemonic, setMnemonic] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const onMnemonicChange = (changedMnemonic: string) => {
+  // -------- CALLBACKS --------
+
+  const onMnemonicChange = React.useCallback((changedMnemonic: string) => {
     const sanitizedMnemonic = sanitizeMnemonic(changedMnemonic, true);
     setMnemonic(sanitizedMnemonic);
     setErrorMessage(null);
-  };
+  }, []);
 
   const onNextPressed = useCallback(async () => {
     if (mnemonic === '') {
@@ -68,7 +73,7 @@ const ImportAccountFromMnemonic: FC<NavProps> = (props) => {
         const invalidWords = sanitizedMnemonic
           .split(' ')
           .filter((w) => w.length > 0 && EnglishMnemonic.wordlist.indexOf(w) === -1)
-          .join(',');
+          .join(', ');
 
         if (invalidWords.length > 0) {
           setErrorMessage(`${t('invalid words')}:\n${invalidWords}`);
@@ -79,12 +84,12 @@ const ImportAccountFromMnemonic: FC<NavProps> = (props) => {
     }
   }, [mnemonic, t, selectAccount, selectedChain, ignoreAddresses, onSuccess]);
 
-  const useDebugMnemonic = () => {
+  const useDebugMnemonic = React.useCallback(() => {
     setMnemonic(
       'hour harbor fame unaware bunker junk garment decrease federal vicious island smile warrior fame right suit portion skate analyst multiply magnet medal fresh sweet',
     );
     setErrorMessage(null);
-  };
+  }, []);
 
   return (
     <StyledSafeAreaView
@@ -107,6 +112,9 @@ const ImportAccountFromMnemonic: FC<NavProps> = (props) => {
         blurOnSubmit
         autoFocus
         onSubmitEditing={onNextPressed}
+        autoCapitalize="none"
+        autoCorrect={false}
+        error={errorMessage !== null}
       />
 
       {errorMessage !== null && (

--- a/src/screens/ImportAccountFromMnemonic/useStyles.ts
+++ b/src/screens/ImportAccountFromMnemonic/useStyles.ts
@@ -16,8 +16,8 @@ const useStyles = makeStyle((theme) => ({
     marginTop: theme.spacing.s,
   },
   errorParagraph: {
-    marginBottom: theme.spacing.xs,
-    color: theme.colors.font.red,
+    marginTop: theme.spacing.s,
+    color: theme.colors.error,
   },
   nextBtn: {
     marginVertical: theme.spacing.xs,


### PR DESCRIPTION
## Description

Closes: DPM-99

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR fixes a bug that prevent the user to write their mnemonic if the first letter is uppercase.
To solve this since all the words of a mnemonic should be lowercase the input now disable the auto capitalization so that all the text is in lowercase.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
