### PR TITLE
fix: profile refresh when returning to the Profile screen

### DIFF
--- a/src/components/ProfileHeader/index.tsx
+++ b/src/components/ProfileHeader/index.tsx
@@ -74,6 +74,12 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = (props) => {
     });
   }, [onEditProfilePicture, pickPicture]);
 
+  // Effect to update the profile and cover picture when they change.
+  React.useEffect(() => {
+    setCoverPicSrc(profile?.coverPicture);
+    setProfilePicSrc(profile?.profilePicture);
+  }, [profile?.coverPicture, profile?.profilePicture]);
+
   return (
     <View style={styles.root}>
       <View style={styles.topRight}>{topRightElement}</View>

--- a/src/screens/Profile/index.tsx
+++ b/src/screens/Profile/index.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { StackScreenProps } from '@react-navigation/stack';
 import StyledSafeAreaView from 'components/StyledSafeAreaView';
 import TopBar from 'components/TopBar';
 import { RootNavigatorParamList } from 'navigation/RootNavigator';
 import ROUTES from 'navigation/routes';
-import { useFocusEffect, useNavigation, useRoute } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
 import EditProfileButton from 'screens/Profile/components/EditProfileButton';
 import useProfileGivenAddress from 'hooks/useProfileGivenAddress';
 import useChainLinksGivenAddress from 'hooks/useChainLinksGivenAddress';
@@ -30,32 +30,15 @@ const Profile = () => {
   const visitingProfile = params?.visitingProfile;
   const canEdit = !visitingProfile;
 
-  const {
-    profile,
-    loading: loadingProfile,
-    refetch: updateProfile,
-  } = useProfileGivenAddress(visitingProfile);
+  // -------- HOOKS --------
 
-  const {
-    chainLinks,
-    loading: loadingChainLinks,
-    refetch: updateChainLinks,
-  } = useChainLinksGivenAddress(profile?.address);
-
-  const {
-    applicationLinks,
-    loading: loadingApplicationLinks,
-    refetch: updateApplicationLinks,
-  } = useApplicationLinksGivenAddress(profile?.address);
-
-  useFocusEffect(
-    useCallback(() => {
-      // Refresh the data when the screen is focused
-      updateProfile();
-      updateChainLinks();
-      updateApplicationLinks();
-    }, [updateApplicationLinks, updateChainLinks, updateProfile]),
+  const { profile, loading: loadingProfile } = useProfileGivenAddress(visitingProfile);
+  const { chainLinks, loading: loadingChainLinks } = useChainLinksGivenAddress(profile?.address);
+  const { applicationLinks, loading: loadingApplicationLinks } = useApplicationLinksGivenAddress(
+    profile?.address,
   );
+
+  // -------- VARIABLES --------
 
   const isLoading = useMemo(
     () => loadingProfile || loadingChainLinks || loadingApplicationLinks,


### PR DESCRIPTION
## Description

Closes: DPM-122

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR fixes the profile refresh when returning to the Profile screen. 
To fix this I have removed the `useFocusEffect` that was triggering the refresh and update the `useStoreProfile` hook
to update the user's cached profile after the transaction succed to avoid to refetch the user's profile when returning in the Profile screen after the transaction.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
