### PR TITLE
fix: WalletConnect invalid QR code

### DIFF
--- a/src/navigation/RootNavigator/HomeTabs/index.tsx
+++ b/src/navigation/RootNavigator/HomeTabs/index.tsx
@@ -22,6 +22,7 @@ import {
   iconModuleGovernanceGray,
   scanQRButton,
 } from 'assets/images';
+import { QrCodeType } from 'screens/ScanQr';
 import BottomBarIcon from './components/BottomBarIcon';
 
 export type HomeTabsParamList = {
@@ -57,7 +58,10 @@ const HomeTabs: FC<NavProps> = ({ navigation }) => {
           customRouteNavigation={{
             // Custom action to navigate to the SCAN_QR_CODE
             // route declared in the root navigator.
-            [ROUTES.SCAN_QR_CODE_BOTTOM_BAR_BUTTON]: () => navigation.navigate(ROUTES.SCAN_QR_CODE),
+            [ROUTES.SCAN_QR_CODE_BOTTOM_BAR_BUTTON]: () =>
+              navigation.navigate(ROUTES.SCAN_QR_CODE, {
+                qrCodeType: QrCodeType.WalletConnect,
+              }),
           }}
         />
       );

--- a/src/screens/WalletConnectSessions/components/EmptySessions/index.tsx
+++ b/src/screens/WalletConnectSessions/components/EmptySessions/index.tsx
@@ -9,6 +9,7 @@ import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RootNavigatorParamList } from 'navigation/RootNavigator';
 import ROUTES from 'navigation/routes';
+import { QrCodeType } from 'screens/ScanQr';
 import useStyles from './useStyles';
 
 const EmptySessions = () => {
@@ -17,7 +18,9 @@ const EmptySessions = () => {
   const styles = useStyles();
 
   const onAuthorize = React.useCallback(() => {
-    navigate.navigate(ROUTES.SCAN_QR_CODE);
+    navigate.navigate(ROUTES.SCAN_QR_CODE, {
+      qrCodeType: QrCodeType.WalletConnect,
+    });
   }, [navigate]);
 
   return (


### PR DESCRIPTION
## Description

This PR attempts to address the “Invalid QR code” error that occurs when trying to create a new WalletConnect authorization with DPM 2.4.x.

![Screenshot_20230922_133950](https://github.com/desmos-labs/dpm/assets/19191465/6a05797f-14fc-4778-bc99-cba22397e41c)


This error is caused by the absence of the `ScanQrCodeParams` during navigation, resulting in an undefined `qrCodeType` value [here](https://github.com/desmos-labs/dpm/blob/6d4d30e4ed9badf25669ad9fe9945429b3daf22f/src/screens/ScanQr/index.tsx#L124)
I've also corrected the navigation on the HomeTabs, but honestly i’m not sure if this is the intended behavior or not.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
