### PR TITLE
feat: add balance visualization when importing a Desmos account

### DIFF
--- a/src/assets/locales/en/common.json
+++ b/src/assets/locales/en/common.json
@@ -47,5 +47,6 @@
   "my address": "My address",
   "copy address": "Copy address",
   "change network": "Change network",
-  "generating": "Generating..."
+  "generating": "Generating...",
+  "balance": "Balance"
 }

--- a/src/hooks/apollo/useAutoCancelQuery.ts
+++ b/src/hooks/apollo/useAutoCancelQuery.ts
@@ -1,0 +1,39 @@
+import {
+  DocumentNode,
+  OperationVariables,
+  QueryHookOptions,
+  QueryResult,
+  TypedDocumentNode,
+  useQuery,
+} from '@apollo/client';
+import React from 'react';
+
+/**
+ * Hook that works like the apollo useQuery hook with the difference that
+ * if the component is unmounted, it cancels the query.
+ */
+export function useAutoCancelQuery<TData = any, TVariables = OperationVariables>(
+  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+  options?: QueryHookOptions<TData, TVariables>,
+): QueryResult<TData, TVariables> {
+  const abortControllerRef = React.useRef(new AbortController());
+
+  React.useEffect(
+    () => () => {
+      abortControllerRef.current.abort();
+    },
+    [],
+  );
+
+  return useQuery(query, {
+    ...options,
+    context: {
+      ...options?.context,
+      fetchOptions: {
+        signal: abortControllerRef.current.signal,
+      },
+    },
+  });
+}
+
+export default useAutoCancelQuery;

--- a/src/screens/SelectAccount/components/AccountListItem/index.tsx
+++ b/src/screens/SelectAccount/components/AccountListItem/index.tsx
@@ -7,6 +7,7 @@ import { getProfileDisplayName } from 'lib/ProfileUtils';
 import { useFetchProfile } from 'screens/SelectAccount/components/AccountListItem/useHooks';
 import { desmosLogoRound } from 'assets/images';
 import useStyles from './useStyles';
+import AccountListItemBalance from '../AccountListItemBalance';
 
 export type AccountListItemProps = {
   /**
@@ -34,6 +35,13 @@ const AccountListItem = (props: AccountListItemProps) => {
   const styles = useStyles(highlight);
   const { profile, profileLoading } = useFetchProfile(address, fetchDelay ?? 1000);
 
+  const showBalance = React.useMemo(
+    () =>
+      // We display the balance only for desmos addresses
+      address.indexOf('desmos1') === 0,
+    [address],
+  );
+
   return (
     <TouchableOpacity style={styles.container} onPress={onPress} disabled={!onPress}>
       <View style={styles.row}>
@@ -60,6 +68,8 @@ const AccountListItem = (props: AccountListItemProps) => {
           <Typography.Caption style={styles.address} ellipsizeMode="middle" numberOfLines={1}>
             {address}
           </Typography.Caption>
+
+          {showBalance && <AccountListItemBalance address={address} />}
         </View>
       </View>
     </TouchableOpacity>

--- a/src/screens/SelectAccount/components/AccountListItemBalance/index.tsx
+++ b/src/screens/SelectAccount/components/AccountListItemBalance/index.tsx
@@ -1,0 +1,71 @@
+import { Coin } from '@desmoslabs/desmjs';
+import { useCurrentChainInfo } from '@recoil/settings';
+import TypographyContentLoaders from 'components/ContentLoaders/Typography';
+import Typography from 'components/Typography';
+import useAutoCancelQuery from 'hooks/apollo/useAutoCancelQuery';
+import { formatCoin } from 'lib/FormatUtils';
+import React from 'react';
+import { View } from 'react-native';
+import GetAccountBalance from 'services/graphql/queries/GetAccountBalance';
+import { useTranslation } from 'react-i18next';
+import useStyles from './useStyles';
+
+export interface AccountListItemBalanceProps {
+  readonly address: string;
+}
+
+/**
+ * Component that displays the balance of an account.
+ */
+const AccountListItemBalance: React.FC<AccountListItemBalanceProps> = ({ address }) => {
+  const { t } = useTranslation();
+  const styles = useStyles();
+  const chainConfig = useCurrentChainInfo();
+  const { loading, data, error } = useAutoCancelQuery(GetAccountBalance, {
+    fetchPolicy: 'cache-and-network',
+    variables: {
+      address,
+    },
+  });
+
+  const balance = React.useMemo<string | undefined>(() => {
+    const coinDenom = chainConfig!.stakeCurrency.coinMinimalDenom;
+    let coin: Coin;
+    if (data) {
+      const coins: Coin[] = data.accountBalance.coins ?? [];
+      coin = coins.find((c) => c.denom === coinDenom) ?? {
+        denom: coinDenom,
+        amount: '0',
+      };
+    } else {
+      coin = {
+        denom: coinDenom,
+        amount: '0',
+      };
+    }
+    return formatCoin(coin);
+  }, [chainConfig, data]);
+
+  if (error) {
+    return (
+      <View style={styles.root}>
+        <Typography.Regular12 style={styles.errorText}>{error.message}</Typography.Regular12>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.root}>
+      <Typography.Regular12>{t('balance')} </Typography.Regular12>
+      {loading ? (
+        <TypographyContentLoaders.Regular12 width={100} />
+      ) : (
+        <Typography.Regular12 numberOfLines={1} ellipsizeMode="middle">
+          {balance}
+        </Typography.Regular12>
+      )}
+    </View>
+  );
+};
+
+export default AccountListItemBalance;

--- a/src/screens/SelectAccount/components/AccountListItemBalance/index.tsx
+++ b/src/screens/SelectAccount/components/AccountListItemBalance/index.tsx
@@ -56,7 +56,7 @@ const AccountListItemBalance: React.FC<AccountListItemBalanceProps> = ({ address
 
   return (
     <View style={styles.root}>
-      <Typography.Regular12>{t('balance')} </Typography.Regular12>
+      <Typography.Regular12>{t('balance')}: </Typography.Regular12>
       {loading ? (
         <TypographyContentLoaders.Regular12 width={100} />
       ) : (

--- a/src/screens/SelectAccount/components/AccountListItemBalance/useStyles.ts
+++ b/src/screens/SelectAccount/components/AccountListItemBalance/useStyles.ts
@@ -1,0 +1,13 @@
+import { makeStyle } from 'config/theme';
+
+const useStyles = makeStyle((theme) => ({
+  root: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
+  errorText: {
+    color: theme.colors.error,
+  },
+}));
+
+export default useStyles;


### PR DESCRIPTION
## Description

Closes: DPM-152

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR introduces the feature to display the account balance when importing a Desmos account.

Here a screen of the final result:
![Screen-20230922-130132](https://github.com/desmos-labs/dpm/assets/6245917/363790f0-97d0-4474-8ee1-d606bd2a5fab)


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
