### PR TITLE
fix: handle locales without thousands separator

### DIFF
--- a/src/lib/FormatUtils/index.ts
+++ b/src/lib/FormatUtils/index.ts
@@ -26,7 +26,8 @@ export const getDecimalSeparator = (locale?: string) => {
 export const getThousandsSeparator = (locale?: string) => {
   // Get the thousands separator characters used in the locale.
   const [, separator] = (1000).toLocaleString(locale);
-  return separator;
+  // Handle the case of locales without thousands separator.
+  return separator === '0' ? '' : separator;
 };
 
 /**


### PR DESCRIPTION
## Description

Closes: DPM-157

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR addresses a bug where on devices with a locale that doesn't have a thousand separator, numbers are incorrectly formatted and parsed.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
