### PR TITLE
fix: multiple dividers in settings sections

### DIFF
--- a/src/components/Flexible/Section/index.tsx
+++ b/src/components/Flexible/Section/index.tsx
@@ -16,10 +16,12 @@ const Section: React.FC<Props> = (props) => {
     const count = React.Children.count(children);
     return React.Children.map(children, (c, index) => {
       const last = count === index + 1;
-      return c && (
-        <View style={[!last && styles.interBorder]} key={`w_${index.toString()}`}>
-          {c}
-        </View>
+      return (
+        c && (
+          <View style={[!last && styles.interBorder]} key={`w_${index.toString()}`}>
+            {c}
+          </View>
+        )
       );
     });
   }, [children, styles.interBorder]);

--- a/src/components/Flexible/Section/index.tsx
+++ b/src/components/Flexible/Section/index.tsx
@@ -16,7 +16,7 @@ const Section: React.FC<Props> = (props) => {
     const count = React.Children.count(children);
     return React.Children.map(children, (c, index) => {
       const last = count === index + 1;
-      return (
+      return c && (
         <View style={[!last && styles.interBorder]} key={`w_${index.toString()}`}>
           {c}
         </View>


### PR DESCRIPTION
## Description

Closes: DPM-159

This PR fixes a bug that was causing the display of two dividers between the "Switch chain" and "Analytics" options in the settings screen.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
