### PR TITLE
feat: improve DTag validation logic when creating a prfile 

### DIFF
--- a/src/assets/locales/en/common.json
+++ b/src/assets/locales/en/common.json
@@ -19,6 +19,7 @@
   "password": "Password",
   "retry": "Retry",
   "available": "Available",
+  "not available": "Not available",
   "send": "Send",
   "transactions": "Transactions",
   "transaction": "Transaction",

--- a/src/assets/locales/en/profile.json
+++ b/src/assets/locales/en/profile.json
@@ -17,5 +17,6 @@
   "user does not have profile": "This user does not yet have a Desmos profile",
   "cover picture upload failed": "Error while uploading cover picture",
   "profile picture upload failed": "Error while uploading profile picture",
-  "cancel error": "Cancel"
+  "cancel error": "Cancel",
+  "dtag required": "DTag is required",
 }

--- a/src/screens/EditProfile/components/DTagAvailability/index.tsx
+++ b/src/screens/EditProfile/components/DTagAvailability/index.tsx
@@ -1,0 +1,79 @@
+import { failIcon, successIcon } from 'assets/images';
+import StyledActivityIndicator from 'components/StyledActivityIndicator';
+import Typography from 'components/Typography';
+import { makeStyle } from 'config/theme';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Image, View } from 'react-native';
+
+interface DTagAvailabilityProps {
+  readonly loading: boolean;
+  readonly isAvailable: boolean | undefined;
+}
+
+/**
+ * Component that provides a feedback to the user about the availability of
+ * their DTag when they are editing their profile.
+ */
+const DTagAvailability: React.FC<DTagAvailabilityProps> = ({ loading, isAvailable }) => {
+  const styles = useStyles();
+  const { t } = useTranslation();
+
+  const availability = React.useMemo(() => {
+    if (loading) {
+      return <StyledActivityIndicator />;
+    }
+    if (isAvailable === undefined) {
+      return null;
+    }
+
+    if (isAvailable) {
+      return (
+        <View style={styles.root}>
+          <Image style={styles.statusIcon} source={successIcon} />
+          <Typography.Regular14 style={styles.availableText}>{t('available')}</Typography.Regular14>
+        </View>
+      );
+    }
+    return (
+      <View style={styles.root}>
+        <Image style={styles.statusIcon} source={failIcon} />
+        <Typography.Regular14 style={styles.notAvailableText}>
+          {t('not available')}
+        </Typography.Regular14>
+      </View>
+    );
+  }, [
+    loading,
+    isAvailable,
+    styles.root,
+    styles.statusIcon,
+    styles.notAvailableText,
+    styles.availableText,
+    t,
+  ]);
+
+  return <View style={styles.root}>{availability}</View>;
+};
+
+export default DTagAvailability;
+
+const useStyles = makeStyle((theme) => ({
+  root: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    minHeight: 24,
+  },
+  statusIcon: {
+    width: 24,
+    height: 24,
+    marginRight: theme.spacing.s,
+  },
+  availableText: {
+    color: theme.colors.feedbackSuccess,
+  },
+  notAvailableText: {
+    color: theme.colors.feedbackError,
+  },
+}));

--- a/src/screens/EditProfile/components/InlineInput/index.tsx
+++ b/src/screens/EditProfile/components/InlineInput/index.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentProps } from 'react';
 import { StyleProp, TextInput, TextStyle, View, ViewStyle } from 'react-native';
 import Typography from 'components/Typography';
+import Spacer from 'components/Spacer';
 import useStyles from './useStyles';
 
 export type InlineInputProps = Omit<ComponentProps<typeof TextInput>, 'style'> & {
@@ -21,7 +22,10 @@ const InlineInput: React.FC<InlineInputProps> = (props) => {
         <TextInput {...props} style={[styles.input, inputStyle]} textAlignVertical="top" />
       </View>
       {error !== undefined && (
-        <Typography.Caption style={styles.errorLabel}>{error}</Typography.Caption>
+        <>
+          <Typography.Caption style={styles.errorLabel}>{error}</Typography.Caption>
+          <Spacer paddingBottom={8} />
+        </>
       )}
     </View>
   );

--- a/src/screens/EditProfile/index.tsx
+++ b/src/screens/EditProfile/index.tsx
@@ -51,7 +51,9 @@ const EditProfile = () => {
   const { validateDTag, validateNickname, validateBiography } = useValidationHooks(profileParams);
 
   const [dTag, setDTag] = useState<string | undefined>(profile?.dtag);
-  const [dTagError, setDTagError] = useState<string | undefined>(undefined);
+  const [dTagError, setDTagError] = useState<string | undefined>(
+    profile === undefined ? t('dtag required') : undefined,
+  );
   const [nickname, setNickname] = useState<string | undefined>(profile?.nickname);
   const [nicknameError, setNicknameError] = useState<string | undefined>(undefined);
   const [biography, setBiography] = useState<string | undefined>(profile?.bio);

--- a/src/screens/EditProfile/index.tsx
+++ b/src/screens/EditProfile/index.tsx
@@ -17,16 +17,27 @@ import SingleButtonModal from 'modals/SingleButtonModal';
 import { DPMImages } from 'types/images';
 import useTrackScreen from 'hooks/analytics/useTrackScreen';
 import { Screens } from 'types/analytics';
-import { useSaveProfile, useValidationHooks } from './useHooks';
+import _ from 'lodash';
+import Spacer from 'components/Spacer';
+import { useCheckDTagAvailability, useSaveProfile, useValidationHooks } from './useHooks';
 import InlineInput from './components/InlineInput';
 import useStyles from './useStyles';
+import DTagAvailability from './components/DTagAvailability';
 
 export type NavProps = StackScreenProps<RootNavigatorParamList, ROUTES.EDIT_PROFILE>;
 
 export interface EditProfileParams {
+  /**
+   * The user's profile to edit.
+   * If this is undefined, the user is creating a new profile.
+   */
   profile: DesmosProfile | undefined;
 }
 
+/**
+ * Screen that allows the user to create a new profile or edit their
+ * profile.
+ */
 const EditProfile = () => {
   const styles = useStyles();
   const theme = useTheme();
@@ -50,6 +61,13 @@ const EditProfile = () => {
   const showModal = useShowModal();
   useTrackScreen(Screens.ProfileEdit);
 
+  const { checkDTagAvailability, isDTagAvailable, checkingDTagAvailability } =
+    useCheckDTagAvailability(profileParams);
+  const debouncedCheckDTagAvailability = React.useMemo(
+    () => _.debounce(checkDTagAvailability, 500),
+    [checkDTagAvailability],
+  );
+
   const showErrorModal = useCallback(
     (title: string, message: string) => {
       showModal(SingleButtonModal, {
@@ -64,6 +82,8 @@ const EditProfile = () => {
 
   const canSave = useMemo(
     () =>
+      !checkingDTagAvailability &&
+      (isDTagAvailable === true || dTag === profile?.dtag) &&
       (dTag !== profile?.dtag ||
         nickname !== profile?.nickname ||
         biography !== profile?.bio ||
@@ -72,14 +92,18 @@ const EditProfile = () => {
       !dTagError &&
       !nicknameError,
     [
-      profile,
-      biography,
+      checkingDTagAvailability,
+      isDTagAvailable,
       dTag,
-      dTagError,
+      profile?.dtag,
+      profile?.nickname,
+      profile?.bio,
       nickname,
-      nicknameError,
-      selectedCoverPicture,
+      biography,
       selectedProfilePicture,
+      selectedCoverPicture,
+      dTagError,
+      nicknameError,
     ],
   );
 
@@ -138,14 +162,22 @@ const EditProfile = () => {
         disabled={!enabled}
       />
     );
-  }, [preparing, canSave, onSavePressed, styles, theme]);
+  }, [
+    canSave,
+    preparing,
+    styles.saveBtn,
+    theme.colors.primary,
+    theme.colors.disabled,
+    onSavePressed,
+  ]);
 
   const onDTagChanged = useCallback(
     (newDTag: string) => {
+      debouncedCheckDTagAvailability(newDTag);
       setDTag(newDTag);
       setDTagError(validateDTag(newDTag));
     },
-    [validateDTag],
+    [debouncedCheckDTagAvailability, validateDTag],
   );
 
   const onNicknameChanged = useCallback(
@@ -185,6 +217,7 @@ const EditProfile = () => {
         />
       }
       touchableWithoutFeedbackDisabled={false}
+      scrollable
     >
       <KeyboardAvoidingView
         keyboardVerticalOffset={Platform.OS === 'ios' ? 110 : 0}
@@ -203,17 +236,6 @@ const EditProfile = () => {
           />
 
           <View style={styles.input}>
-            {/* Nickname */}
-            <InlineInput
-              label={t('nickname')}
-              placeholder={t('nickname')}
-              value={nickname}
-              onChangeText={onNicknameChanged}
-              error={nicknameError}
-            />
-
-            <Divider />
-
             {/* DTag */}
             <InlineInput
               label={t('dtag')}
@@ -222,7 +244,25 @@ const EditProfile = () => {
               error={dTagError}
               onChangeText={onDTagChanged}
             />
+            {dTagError === undefined && dTag !== profile?.dtag && (
+              <>
+                <DTagAvailability
+                  loading={checkingDTagAvailability}
+                  isAvailable={isDTagAvailable}
+                />
+                <Spacer paddingBottom={8} />
+              </>
+            )}
+            <Divider />
 
+            {/* Nickname */}
+            <InlineInput
+              label={t('nickname')}
+              placeholder={t('nickname')}
+              value={nickname}
+              onChangeText={onNicknameChanged}
+              error={nicknameError}
+            />
             <Divider />
 
             {/* Biography */}

--- a/src/services/graphql/queries/GetProfileForDTag.ts
+++ b/src/services/graphql/queries/GetProfileForDTag.ts
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client';
+import PROFILE_FIELDS from './fragments/ProfilesFields';
+
+const GetProfileForDTag = gql`
+  ${PROFILE_FIELDS}
+  query GetProfileForAddress($dtag: String) @api(name: desmos) {
+    profile(where: { dtag: { _eq: $dtag } }) {
+      ...ProfileFields
+    }
+  }
+`;
+
+export default GetProfileForDTag;


### PR DESCRIPTION
## Description

Closes: DPM-158, DPM-161

This PR enhances the DTag validation logic by:

1. Requiring a non-empty DTag when the user is creating their first profile.
2. Adding validation logic to check if another user has the same DTag.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
