### PR TITLE
refactor: update modal behavior

### DIFF
--- a/src/modals/AmountAndMemoModal/index.tsx
+++ b/src/modals/AmountAndMemoModal/index.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import Typography from 'components/Typography';
 import TxMemoInput from 'components/TxMemoInput';
 import Spacer from 'components/Spacer';
-import { View } from 'react-native';
+import DKeyboardAvoidingView from 'components/DKeyboardAvoidingView';
 import useStyles from './useStyles';
 
 export type ErrorModalParams = {
@@ -63,7 +63,7 @@ const AmountAndMemoModal: React.FC<ModalComponentProps<ErrorModalParams>> = (pro
   }, [amount, closeModal, memo, onSelect]);
 
   return (
-    <View style={styles.root}>
+    <DKeyboardAvoidingView style={styles.root}>
       <Typography.H6 style={styles.title}>{title}</Typography.H6>
 
       <Spacer paddingVertical={12} />
@@ -83,7 +83,7 @@ const AmountAndMemoModal: React.FC<ModalComponentProps<ErrorModalParams>> = (pro
       <Button onPress={onNextPressed} disabled={amount === undefined} mode="contained">
         {t('common:next')}
       </Button>
-    </View>
+    </DKeyboardAvoidingView>
   );
 };
 

--- a/src/modals/AmountAndMemoModal/useStyles.ts
+++ b/src/modals/AmountAndMemoModal/useStyles.ts
@@ -1,8 +1,9 @@
 import { makeStyle } from 'config/theme';
+import { Platform } from 'react-native';
 
 const useStyles = makeStyle((theme) => ({
   root: {
-    paddingBottom: theme.spacing.l,
+    paddingBottom: Platform.OS === 'ios' ? theme.spacing.l : 0,
   },
   title: {
     alignSelf: 'center',

--- a/src/modals/ModalScreen/index.tsx
+++ b/src/modals/ModalScreen/index.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { RootNavigatorParamList } from 'navigation/RootNavigator';
 import ROUTES from 'navigation/routes';
-import DKeyboardAvoidingView from 'components/DKeyboardAvoidingView';
 import { useCloseModal } from './useHooks';
 import useStyles from './useStyles';
 
@@ -112,9 +111,9 @@ const ModalScreen: React.FC<NavProps> = ({ route, navigation }) => {
         <TouchableOpacity onPress={closeModal} style={styles.closePopupArea} />
       ) : null}
 
-      <DKeyboardAvoidingView style={contentStyle} keyboardVerticalOffset={0}>
+      <View style={contentStyle}>
         <ModalContent params={params} closeModal={closeModal} />
-      </DKeyboardAvoidingView>
+      </View>
     </View>
   );
 };


### PR DESCRIPTION
## Description

Closes: DPM-174

This PR updates what was done with #251 by reverting the changes to the `ModalScreen` component and moving the usage of the `DKeyboardAvoidingView` inside the `AmountAndMemoModal` instead. 

It also improves the bottom padding of `AmountAndMemoModal` by making it non-zero only for iOS devices, to prevent visualization issues with the `DKeyboardAvoidingView`. 

**Note**: A test run on the iOS simulator is needed from @ale-mazz before releasing this. The things that should be tested are:

1. The `AmountAndMemoModal` is shown properly, and trying to input something does not make the keyboard cover everything (BON-173).
2. The `SingleButtonModal` is shown properly, and the paddings on the content are set properly (BON-174).

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
