### PR TITLE
fix: inline code not displayed when converting markdown text to plaintext

### DIFF
--- a/src/lib/FormatUtils/index.ts
+++ b/src/lib/FormatUtils/index.ts
@@ -214,12 +214,18 @@ export const makrdownToPlainText = (markdownText: string): string => {
   return stringToTokens(withNewLines, markdownItInstance)
     .filter((t) => t.children !== null)
     .flatMap((t) => t.children)
-    .filter((t) => (t.type === 'text' && t.content !== '') || t.type === 'softbreak')
+    .filter(
+      (t) =>
+        (t.type === 'text' && t.content !== '') ||
+        t.type === 'softbreak' ||
+        t.type === 'code_inline',
+    )
     .reduce((previousValue, token) => {
-      if (token.type === 'text') {
-        return `${previousValue}${token.content} `;
+      if (token.type === 'softbreak') {
+        return `${previousValue}\n`;
       }
-      return `${previousValue}\n`;
+
+      return `${previousValue}${token.content} `;
     }, '');
 };
 

--- a/src/screens/GovernanceProposalDetails/components/ProposalDetails/index.tsx
+++ b/src/screens/GovernanceProposalDetails/components/ProposalDetails/index.tsx
@@ -80,7 +80,7 @@ const ProposalDetails: React.FC<ProposalDetailsProps> = ({ proposal }) => {
     <View>
       {/* Description */}
       <Typography.SemiBold14>{t('common:description')}</Typography.SemiBold14>
-      <StyledMarkDown>{proposal.description.replace(/\\n/gm, '\n')}</StyledMarkDown>
+      <StyledMarkDown>{proposal.description}</StyledMarkDown>
       <Spacer paddingVertical={12} />
 
       {/* Plan */}


### PR DESCRIPTION
## Description

Closes: DPM-164

This PR fixes a bug that prevents the display of inline code when converting markdown text into plain text.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
