### PR TITLE
feat: keep wallet unlocked after first unlock

### DIFF
--- a/src/hooks/useUnlockWallet.ts
+++ b/src/hooks/useUnlockWallet.ts
@@ -3,10 +3,14 @@ import { useCallback } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { RootNavigatorParamList } from 'navigation/RootNavigator';
 import { StackNavigationProp } from '@react-navigation/stack';
-import { Wallet } from 'types/wallet';
+import { LedgerWallet, Wallet, WalletType } from 'types/wallet';
 import ROUTES from 'navigation/routes';
 import { useActiveAccount } from '@recoil/activeAccount';
-import { SigningMode } from '@desmoslabs/desmjs';
+import { OfflineSignerAdapter, SigningMode } from '@desmoslabs/desmjs';
+import { useGetUserUnlockedWallet, useSetUnlockedWallet } from '@recoil/wallet';
+import useConnectToLedger from 'hooks/useConnectToLedger';
+import { LedgerApps } from 'config/LedgerApps';
+import { LedgerSigner } from '@cosmjs/ledger-amino';
 
 /**
  * Hooks that provides a function to unlock and access a user wallet.
@@ -15,23 +19,65 @@ const useUnlockWallet = () => {
   const returnToCurrentScreen = useReturnToCurrentScreen();
   const navigator = useNavigation<StackNavigationProp<RootNavigatorParamList>>();
   const activeAccount = useActiveAccount();
+  const connectToLedger = useConnectToLedger();
+  const setUnlockedWallet = useSetUnlockedWallet();
+  const getUnlockedWallet = useGetUserUnlockedWallet();
 
   return useCallback(
-    (toUnlockAddress?: string, signingMode?: SigningMode) => {
+    async (toUnlockAddress?: string, signingMode?: SigningMode): Promise<Wallet | undefined> => {
       const address = toUnlockAddress ?? activeAccount!.address;
 
       if (address === undefined) {
         return Promise.reject(new Error('no account selected'));
+      }
+      const previuslyUnlockedWallet = getUnlockedWallet(address);
+
+      if (previuslyUnlockedWallet) {
+        // Special case for the Ledger hardware wallet.
+        if (previuslyUnlockedWallet.type === WalletType.Ledger) {
+          // The Ledger is still connected, lets return the wallet.
+          if (previuslyUnlockedWallet.transport.notYetDisconnected) {
+            return previuslyUnlockedWallet;
+          }
+
+          // The ledger is not connected, reopen the connection.
+          const ledgerApp = LedgerApps.find(
+            ({ name }) => name === previuslyUnlockedWallet.ledgerAppName,
+          )!;
+          const ledgerTransport = await connectToLedger(ledgerApp);
+          // The user cancelled the connection.
+          if (ledgerTransport === undefined) {
+            return undefined;
+          }
+
+          const newWalletInstance: LedgerWallet = {
+            ...previuslyUnlockedWallet,
+            signer: new OfflineSignerAdapter(
+              new LedgerSigner(ledgerTransport, {
+                prefix: previuslyUnlockedWallet.addressPrefix,
+                ledgerAppName: ledgerApp.name,
+                minLedgerAppVersion: ledgerApp.minVersion,
+                hdPaths: [previuslyUnlockedWallet.hdPath],
+              }),
+            ),
+            transport: ledgerTransport,
+          };
+          setUnlockedWallet(address, newWalletInstance);
+          return newWalletInstance;
+        }
+        return previuslyUnlockedWallet;
       }
 
       return new Promise<Wallet | undefined>((resolve) => {
         navigator.navigate(ROUTES.UNLOCK_WALLET, {
           address,
           onSuccess: (wallet) => {
+            setUnlockedWallet(address, wallet);
             resolve(wallet);
             returnToCurrentScreen();
           },
           onCancel: () => {
+            setUnlockedWallet(address, undefined);
             resolve(undefined);
             returnToCurrentScreen();
           },
@@ -39,7 +85,14 @@ const useUnlockWallet = () => {
         });
       });
     },
-    [activeAccount, navigator, returnToCurrentScreen],
+    [
+      activeAccount,
+      connectToLedger,
+      getUnlockedWallet,
+      navigator,
+      returnToCurrentScreen,
+      setUnlockedWallet,
+    ],
   );
 };
 

--- a/src/lib/WalletUtils/generate.ts
+++ b/src/lib/WalletUtils/generate.ts
@@ -44,6 +44,7 @@ export const generateLedgerAccountWallets = async (
       hdPath: hdPaths[i],
       ledgerAppName: app.name,
       addressPrefix: prefix,
+      transport,
     },
     account: {
       walletType: WalletType.Ledger,

--- a/src/recoil/wallet.ts
+++ b/src/recoil/wallet.ts
@@ -1,0 +1,51 @@
+import React from 'react';
+import { atom, useRecoilValue, useSetRecoilState } from 'recoil';
+import { Wallet } from 'types/wallet';
+
+/**
+ * Recoil state that holds the wallets that have been unlocked.
+ * Each wallet is saved in a Record where the key is the address associated with that wallet.
+ * These wallets are stored to prevent the user from having to unlock
+ * the wallet multiple times when they are performing multiple operations.
+ */
+const unlockedWalletsAppState = atom<Record<string, Wallet>>({
+  key: 'unlockedWalletsAppState',
+  default: {},
+  dangerouslyAllowMutability: true,
+});
+
+/**
+ * Hook that provides a function update the unlocked wallet associated
+ * to a user.
+ */
+export const useSetUnlockedWallet = () => {
+  const setUnlockedWallet = useSetRecoilState(unlockedWalletsAppState);
+
+  return React.useCallback(
+    (userAddress: string, wallet: Wallet | undefined) => {
+      setUnlockedWallet((currentValue) => {
+        const newValue = { ...currentValue };
+        if (wallet) {
+          newValue[userAddress] = wallet;
+        } else {
+          delete newValue[userAddress];
+        }
+        return newValue;
+      });
+    },
+    [setUnlockedWallet],
+  );
+};
+
+/**
+ * Hook that provides a function that returns the unlocked wallet associated
+ * to a user.
+ */
+export const useGetUserUnlockedWallet = () => {
+  const unlockedWallets = useRecoilValue(unlockedWalletsAppState);
+
+  return React.useCallback(
+    (userAddress: string) => unlockedWallets[userAddress],
+    [unlockedWallets],
+  );
+};

--- a/src/screens/UnlockWallet/useHooks.ts
+++ b/src/screens/UnlockWallet/useHooks.ts
@@ -80,6 +80,7 @@ const useInitLedgerWallet = () => {
             hdPaths: [hdPath],
           }),
         ),
+        transport,
       } as LedgerWallet);
     },
     [connectToLedger],

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -95,12 +95,16 @@ export interface LedgerWallet extends BaseWallet {
    * Name of the app used to generate this wallet.
    */
   readonly ledgerAppName: string;
+  /**
+   * Transport used to connect to the Ledger device.
+   */
+  readonly transport: BluetoothTransport;
 }
 
 /**
  * [LedgerWallet] that can be serialized to JSON.
  */
-export type SerializableLedgerWallet = Omit<LedgerWallet, 'signer' | 'hdPath'> & {
+export type SerializableLedgerWallet = Omit<LedgerWallet, 'signer' | 'hdPath' | 'transport'> & {
   version: WalletSerializationVersion.Ledger;
   /**
    * HD Derivation path used to generate the user


### PR DESCRIPTION
## Description

Closes: DPM-165

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR enables the application to keep the user's wallets unlocked after they have been initially unlocked. This helps to speed up operations and prevent multiple password prompts.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
