### PR TITLE
feat: update usePaginatedData hook

### DIFF
--- a/src/hooks/usePaginatedData.ts
+++ b/src/hooks/usePaginatedData.ts
@@ -337,4 +337,3 @@ export function usePaginatedData<T, F extends Object>(
     totalItemsCount,
   };
 }
-

--- a/src/hooks/usePaginatedData.ts
+++ b/src/hooks/usePaginatedData.ts
@@ -205,11 +205,11 @@ export function usePaginatedData<T, F extends Object>(
         await delay(extraDelay);
       }
 
-      if (fetchedItems.length >= 0) {
-        dataRef.current = reset ? fetchedItems : [...dataRef.current, ...fetchedItems];
-        setData(dataRef.current);
-        onDataChangedRef.current?.(dataRef.current);
-      } else if (fetchError !== undefined) {
+      dataRef.current = reset ? fetchedItems : [...dataRef.current, ...fetchedItems];
+      setData(dataRef.current);
+      onDataChangedRef.current?.(dataRef.current);
+
+      if (fetchError !== undefined) {
         setError(fetchError);
       }
 

--- a/src/hooks/usePaginatedData.ts
+++ b/src/hooks/usePaginatedData.ts
@@ -1,8 +1,10 @@
-import React, { useRef } from 'react';
+import { delay } from 'lib/PromiseUtils';
 import _ from 'lodash';
+import React from 'react';
 
 /**
  * Type that represents the data fetched from @see {@link FetchDataFunction} function.
+ * @typeParam T - Type of the fetched data.
  */
 export type PaginatedResult<T> = {
   /**
@@ -20,23 +22,51 @@ export type PaginatedResult<T> = {
 /**
  * Type that represents a function capable of fetching data in a paginated
  * manner.
+ * @typeParam T - Type of the fetched data.
+ * @typeParam F - Type of the filter.
  */
-export type FetchDataFunction<T, F> = (
+export type FetchDataFunction<T, F extends Object = {}> = (
   offset: number,
   limit: number,
   filter?: F,
 ) => PaginatedResult<T> | Promise<PaginatedResult<T>>;
 
-export interface PaginatedDataConfig {
+/**
+ * Interface that represents the configurations that can be provided to the
+ * usePaginatedData hook.
+ */
+export interface PaginatedDataConfig<T, F extends Object> {
   /**
    * Number of items that should be fetched per page.
    */
   readonly itemsPerPage: number;
   /**
+   * Amount of ms that the fetchMore function will wait
+   * before completing.
+   */
+  readonly extraDelay?: number;
+  /**
    * Debounce time applied to the update filter function.
    * If undefined will be used 300ms.
    */
   readonly updateFilterDebounceTimeMs?: number;
+  /**
+   * Filter that will be applied at the beginning.
+   */
+  readonly initialFilter?: F;
+  /**
+   * Callback that will be called each time the data changes.
+   * This can be used for example to implement a caching logic by
+   * updating a state that is outside of this hook and use this
+   * ones in a list instead of the items returned by this hook.
+   */
+  readonly onDataChanged?: (data: T[]) => any;
+  /**
+   * Optional action to exec before executing the refetch action.
+   * This can be usefull if you need to perform an action before
+   * refreshing the data.
+   */
+  readonly preRefetchAction?: () => Promise<any>;
   /**
    * If this field is true the first page will be automatically fetched
    * instead of waiting for a call to the fetchMore function.
@@ -44,6 +74,11 @@ export interface PaginatedDataConfig {
    * that don't call the fetchMore function if the list is empty.
    */
   readonly autoFetchFirstPage?: boolean;
+  /**
+   * Optional function to get the total number of items that can be
+   * fetched.
+   */
+  readonly getTotalItemsCount?: () => Promise<number>;
 }
 
 /**
@@ -51,49 +86,106 @@ export interface PaginatedDataConfig {
  * filter.
  * @param fetchFunction - Function to fetch the data.
  * @param config - Data pagination config.
- * @param initialFilter - Filter that will be applied at the beginning.
+ * @typeParam T - Type of the fetched data.
+ * @typeParam F - Type of the filter.
  */
-export function usePaginatedData<T, F>(
+export function usePaginatedData<T, F extends Object>(
   fetchFunction: FetchDataFunction<T, F>,
-  config: PaginatedDataConfig,
-  initialFilter?: F,
+  config: PaginatedDataConfig<T, F>,
 ) {
-  const { autoFetchFirstPage } = config;
+  // Hook configs
+  const {
+    itemsPerPage,
+    extraDelay,
+    updateFilterDebounceTimeMs,
+    initialFilter,
+    onDataChanged,
+    preRefetchAction,
+    autoFetchFirstPage,
+    getTotalItemsCount,
+  } = config;
 
-  // Variables saved as ref to prevent the recreation of fetchMore
-  const currentOffsetRef = useRef(0);
+  // Internal state variable, those are refs to avoid renders when
+  // the fetch more functions update those fields after each invocation.
+  const firstExecution = React.useRef(true);
+  const currentOffset = React.useRef<number>(0);
+  const fetchingOffset = React.useRef<number>();
+  const endReachedRef = React.useRef(false);
+  const filter = React.useRef(initialFilter);
+  const dataRef = React.useRef<T[]>([]);
+  const preRefetchActionRef = React.useRef(preRefetchAction);
+  const getTotalItemsCountRef = React.useRef(getTotalItemsCount);
 
-  const firstExecution = useRef(true);
+  // Keep this ref that we update with an effect
+  // to prevent the recreation of the `fetchMore` function
+  // when this function changes.
+  const onDataChangedRef = React.useRef(onDataChanged);
+
+  // -------- STATES --------
   const [data, setData] = React.useState<T[]>([]);
-  const [filter, setFilter] = React.useState<F | undefined>(initialFilter);
-  const [loading, setLoading] = React.useState(true);
+  const [filterState, setFilterState] = React.useState(initialFilter);
+  const [loading, setLoading] = React.useState(false);
   const [refreshing, setRefreshing] = React.useState(false);
   const [error, setError] = React.useState<Error>();
+  const [totalItemsCount, setTotalItemsCount] = React.useState(0);
 
-  const fetchMore = React.useCallback(
-    async (overrideOffset?: number, resetState?: boolean) => {
-      setLoading(true);
+  // -------- CALLBACKS --------
+
+  // Function to fetch the next `itemsPerPage` items.
+  const fetchDataFunction = React.useCallback(
+    async (reset?: boolean) => {
+      if (endReachedRef.current && reset !== true) {
+        // Nothing more to fetch.
+        return;
+      }
+
+      // Current offset.
+      let fetchOffset = reset ? 0 : currentOffset.current;
+
+      // Prevent fetch of the same offset.
+      if (reset !== true && fetchingOffset.current === fetchOffset) {
+        return;
+      }
+
+      if (reset !== true) {
+        setLoading(true);
+      } else {
+        setRefreshing(true);
+      }
+      fetchingOffset.current = fetchOffset;
+
+      // Get the total items at the first fetch.
+      if (fetchOffset === 0 && getTotalItemsCountRef.current !== undefined) {
+        try {
+          const totalCount = await getTotalItemsCountRef.current();
+          setTotalItemsCount(totalCount);
+        } catch (e) {
+          // Ignored.
+          setTotalItemsCount(0);
+        }
+      }
+
       // Temp var where we keep the fetched items until we have them all.
       const fetchedItems: T[] = [];
-      // Current offset.
-      let fetchOffset = overrideOffset ?? currentOffsetRef.current;
+
       let stopFetch = false;
+      let fetchError: Error | undefined;
 
       // Loop to fetch exactly itemsPerPage elements even if the fetchFunction
       // returns less than itemsPerPage items because have filtered the
       // items inside the requested page.
-      while (fetchedItems.length < config.itemsPerPage && !stopFetch) {
+      let endReached: boolean | undefined;
+      while (fetchedItems.length < itemsPerPage && !stopFetch) {
         // Compute how many items we need to fetch
-        const fetchLimit = config.itemsPerPage - fetchedItems.length;
-        let endReached: boolean | undefined;
+        const fetchLimit = itemsPerPage - fetchedItems.length;
         let fetchedData: T[];
         try {
           // eslint-disable-next-line no-await-in-loop
-          const fetchResult = await fetchFunction(fetchOffset, fetchLimit, filter);
+          const fetchResult = await fetchFunction(fetchOffset, fetchLimit, filter.current);
           fetchedData = fetchResult.data;
           endReached = fetchResult.endReached;
         } catch (e) {
-          setError(e as Error);
+          fetchError = e as Error;
           fetchedData = [];
           endReached = true;
         }
@@ -103,28 +195,71 @@ export function usePaginatedData<T, F>(
         stopFetch = endReached ?? fetchedData.length < fetchLimit;
       }
 
+      // Check if we have fetched all the items from the server.
+      endReachedRef.current = endReached ?? fetchedItems.length < itemsPerPage;
+
       // Update the current offset.
-      currentOffsetRef.current = fetchOffset;
+      currentOffset.current = fetchOffset;
 
-      // Update the stored items.
-      setData((currentData) => (resetState ? fetchedItems : [...currentData, ...fetchedItems]));
+      if (extraDelay !== undefined && extraDelay > 0) {
+        await delay(extraDelay);
+      }
 
-      setLoading(false);
+      if (fetchedItems.length >= 0) {
+        dataRef.current = reset ? fetchedItems : [...dataRef.current, ...fetchedItems];
+        setData(dataRef.current);
+        onDataChangedRef.current?.(dataRef.current);
+      } else if (fetchError !== undefined) {
+        setError(fetchError);
+      }
+
+      if (reset !== true) {
+        setLoading(false);
+      } else {
+        setRefreshing(false);
+      }
     },
-    [fetchFunction, filter, config.itemsPerPage],
+    [extraDelay, fetchFunction, itemsPerPage],
   );
 
+  const fetchMore = React.useCallback(async () => {
+    await fetchDataFunction();
+  }, [fetchDataFunction]);
+
+  // Function to refresh the data, all the items fetched will be
+  // cleared and the `fetchDataFunction` function will start to fetch the items
+  // from the items with index 0.
   const refresh = React.useCallback(async () => {
     setError(undefined);
-    setRefreshing(true);
-    await fetchMore(0, true);
-    setRefreshing(false);
-  }, [fetchMore]);
+    try {
+      if (preRefetchActionRef.current !== undefined) {
+        setRefreshing(true);
+        await preRefetchActionRef.current();
+      }
+      await fetchDataFunction(true);
+    } catch (e) {
+      setError(e as Error);
+    }
+  }, [fetchDataFunction]);
+
+  // Function to update the current filter.
+  const setFilter = React.useCallback(
+    (newFilter: React.SetStateAction<F | undefined>) => {
+      setFilterState(newFilter);
+      if (typeof newFilter === 'function') {
+        filter.current = newFilter(filter.current);
+      } else {
+        filter.current = newFilter;
+      }
+      refresh();
+    },
+    [refresh],
+  );
 
   // Debounced version of setFilter.
   const debouncedSetFilter = React.useMemo(
-    () => _.debounce(setFilter, config?.updateFilterDebounceTimeMs ?? 300),
-    [config?.updateFilterDebounceTimeMs],
+    () => _.debounce(setFilter, updateFilterDebounceTimeMs ?? 300),
+    [setFilter, updateFilterDebounceTimeMs],
   );
 
   // Function to update the filter.
@@ -133,12 +268,21 @@ export function usePaginatedData<T, F>(
       if (!noDebounce) {
         debouncedSetFilter(newFilter);
       } else {
+        // Cancel a possible debounced execution.
         debouncedSetFilter.cancel();
+        // Update the filter and trigger the refresh.
         setFilter(newFilter);
       }
     },
-    [debouncedSetFilter],
+    [setFilter, debouncedSetFilter],
   );
+
+  // -------- EFFECTS --------
+
+  // Hook to update the onDataChangedRef.
+  React.useEffect(() => {
+    onDataChangedRef.current = onDataChanged;
+  }, [onDataChanged]);
 
   // Hook to clear the debounced function when the component is destroyed.
   React.useEffect(
@@ -148,22 +292,32 @@ export function usePaginatedData<T, F>(
     [debouncedSetFilter],
   );
 
+  // Hook to update the preRefetchAction ref.
   React.useEffect(() => {
+    preRefetchActionRef.current = preRefetchAction;
+  }, [preRefetchAction]);
+
+  // Hook to update the getTotalItemsCount ref.
+  React.useEffect(() => {
+    getTotalItemsCountRef.current = getTotalItemsCount;
+  }, [getTotalItemsCount]);
+
+  // Effect to trigger the refresh function when `fetchFunction` or
+  // the `itemsPerPage` changes.
+  React.useEffect(() => {
+    // Check if is not the first time that this effect has been triggered,
+    // in this case we call the refresh function since that means that the
+    // `fetchFunction` or `itemsPerPage` have changed.
     if (!firstExecution.current) {
       refresh();
     } else {
       firstExecution.current = false;
     }
-
-    // Safe to ignore we want to call the refresh function
-    // only if the filter changes or if the provided fetch function
-    // has changed.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filter, fetchFunction]);
+  }, [refresh]);
 
   React.useEffect(() => {
     if (autoFetchFirstPage) {
-      fetchMore();
+      fetchDataFunction();
     }
     // Safe to disable we want to execute this effect only when
     // the autoFetchFirstPage flag changes.
@@ -172,11 +326,15 @@ export function usePaginatedData<T, F>(
 
   return {
     data,
+    filter: filterState,
     fetchMore,
     refresh,
     loading,
+    initialLoading: false,
     refreshing,
     updateFilter,
     error,
+    totalItemsCount,
   };
 }
+

--- a/src/screens/ScanQr/components/QrCodeScanner/index.tsx
+++ b/src/screens/ScanQr/components/QrCodeScanner/index.tsx
@@ -105,6 +105,7 @@ const QrCodeScanner: FC<QrCodeScannerProps> = ({ onQrCodeDetected, stopRecogniti
     stopRecognition,
     frameProcessor,
     styles.noPermissionsContainer,
+    styles.indicatorView,
     requestPermission,
   ]);
 };

--- a/src/screens/SelectAccount/components/AccountPicker/useHooks.ts
+++ b/src/screens/SelectAccount/components/AccountPicker/useHooks.ts
@@ -142,11 +142,8 @@ const useGetGenerateWalletFunction = () =>
 export const useGeneratePaginatedWallets = (params: AccountPickerParams) => {
   const generateFunction = useGetGenerateWalletFunction();
 
-  return usePaginatedData(
-    generateFunction,
-    {
-      itemsPerPage: 10,
-    },
-    params,
-  );
+  return usePaginatedData(generateFunction, {
+    itemsPerPage: 10,
+    initialFilter: params,
+  });
 };

--- a/src/screens/SelectValidator/index.tsx
+++ b/src/screens/SelectValidator/index.tsx
@@ -29,10 +29,13 @@ const SelectValidator: FC<NavProps> = (props) => {
   const loadValidatorPage = useFetchValidators();
   const { data, loading, fetchMore, refresh, refreshing, updateFilter, error } = usePaginatedData(
     loadValidatorPage,
-    { itemsPerPage: 50, updateFilterDebounceTimeMs: 500 },
     {
-      moniker: '',
-      votingPowerOrder: 'desc',
+      itemsPerPage: 50,
+      updateFilterDebounceTimeMs: 500,
+      initialFilter: {
+        moniker: '',
+        votingPowerOrder: 'desc',
+      },
     },
   );
 

--- a/src/screens/SendTokens/components/RecipientsList/hooks.ts
+++ b/src/screens/SendTokens/components/RecipientsList/hooks.ts
@@ -55,10 +55,7 @@ const useFetchProfiles = () => {
 };
 
 export const useProfilesFromNickNameOrDtag = () =>
-  usePaginatedData<DesmosProfile, string>(
-    useFetchProfiles(),
-    {
-      itemsPerPage: 20,
-    },
-    '',
-  );
+  usePaginatedData<DesmosProfile, string>(useFetchProfiles(), {
+    itemsPerPage: 20,
+    initialFilter: '',
+  });


### PR DESCRIPTION
## Description

Closes: DPM-184

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR updates the `usePaginatedData` hook with changes made while working on other projects.  
The new features include:

1. The possibility to implement caching logic using the `onDataChanged` field.
2. The ability to execute an operation before data is refreshed through the `preRefetchAction` field.
3. The option to get the total item count through the `getTotalItemsCount` field.

Additionally, the changes improve some behaviors of the hook:

1. Fix weird refresh behaviors on iOS.
2. Avoid performing a fetch request when all elements have been fetched.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
