### PR TITLE
fix(ios): send input visualization after pasting and address on iOS

### DIFF
--- a/src/components/TextInput/useStyles.ts
+++ b/src/components/TextInput/useStyles.ts
@@ -24,7 +24,6 @@ const useStyles = makeStyleWithProps((props: TextInputProps, theme) => ({
     flexGrow: 1,
     flexShrink: 1,
     textAlignVertical: props.multiline === true ? 'top' : 'center',
-    height: '100%',
     color: theme.colors.font['1'],
     minHeight: props.numberOfLines !== undefined ? 25 * props.numberOfLines : undefined,
   },

--- a/src/screens/ImportAccountFromMnemonic/index.tsx
+++ b/src/screens/ImportAccountFromMnemonic/index.tsx
@@ -104,7 +104,8 @@ const ImportAccountFromMnemonic: FC<NavProps> = (props) => {
         {t('recovery passphrase')}
       </Typography.Body>
       <TextInput
-        style={styles.mnemonicInput}
+        style={styles.mnemonic}
+        inputStyle={styles.mnemonicInput}
         textAlignVertical={'top'}
         placeholder={t('enter recovery passphrase placeholder')}
         value={mnemonic}

--- a/src/screens/ImportAccountFromMnemonic/useStyles.ts
+++ b/src/screens/ImportAccountFromMnemonic/useStyles.ts
@@ -5,9 +5,12 @@ const useStyles = makeStyle((theme) => ({
     marginTop: theme.spacing.l,
     textTransform: 'capitalize',
   },
-  mnemonicInput: {
+  mnemonic: {
     marginTop: theme.spacing.s,
     minHeight: 110,
+  },
+  mnemonicInput: {
+    height: '100%',
   },
   advanceSettingsBtn: {
     marginTop: theme.spacing.s,

--- a/src/screens/Stake/index.tsx
+++ b/src/screens/Stake/index.tsx
@@ -71,7 +71,7 @@ const Stake: React.FC<NavProps> = (props) => {
 
   return (
     <StyledSafeAreaView
-      topBar={<TopBar stackProps={props} title={t('stake')} />}
+      topBar={<TopBar style={styles.topBar} stackProps={props} title={t('stake')} />}
       paddingHorizontal={0}
       touchableWithoutFeedbackDisabled={false}
     >

--- a/src/screens/Stake/useStyles.ts
+++ b/src/screens/Stake/useStyles.ts
@@ -1,6 +1,9 @@
 import { makeStyle } from 'config/theme';
 
 const useStyles = makeStyle((theme) => ({
+  topBar: {
+    marginHorizontal: theme.spacing.m,
+  },
   stakingMessageContainer: {
     padding: 4,
     // Add trailing 16 to make the 0.1 opacity


### PR DESCRIPTION
## Description

Closes: DPM-185

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR addresses a bug in iOS that was causing the send input to display the user's address in multiple lines instead of a single one.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
