### PR TITLE
feat: allow to paste the WalletConnect uri

### DIFF
--- a/src/assets/locales/en/walletConnect.json
+++ b/src/assets/locales/en/walletConnect.json
@@ -8,6 +8,8 @@
   "ability to revoke authorizations": "You will be able to revoke such authorizations inside your Authorization page",
   "deny": "Deny",
   "authorize": "Authorize",
+  "paste uri": "Paste WalletConnect URI",
+  "no uri in clipboard": "No WalletConnect URI in clipboard",
   "show pending requests": "Show pending requests",
   "approve": "Approve",
   "reject": "Reject",

--- a/src/screens/ScanQr/useStyles.ts
+++ b/src/screens/ScanQr/useStyles.ts
@@ -1,6 +1,6 @@
 import { makeStyle } from 'config/theme';
 
-const useStyles = makeStyle(() => ({
+const useStyles = makeStyle((theme) => ({
   root: {
     backgroundColor: 'rgba(0, 0, 0, 0.7)',
   },
@@ -16,10 +16,11 @@ const useStyles = makeStyle(() => ({
     elevation: 9,
     zIndex: 99,
   },
-  debugUri: {
+  pasteUri: {
     position: 'absolute',
-    bottom: 0,
+    bottom: theme.spacing.m,
     left: 0,
+    right: 0,
   },
   pairingIndicator: {
     position: 'absolute',


### PR DESCRIPTION
## Description

Closes: DPM-189

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR adds a button to the bottom of the `ScanQr` screen that will allow the user to quickly paste a _WalletConnect_ URI and start a pair request.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a button to paste a URI directly for processing in the QR scanner screen.
- **Enhancements**
	- Updated QR scanner screen styling for better user interface alignment.
- **Removed**
	- Removed unused text input field from the QR scanner screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->